### PR TITLE
Feature/add ramp up attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Next add the `JUnitPerfTest` annotation to the unit test you would like to conve
 
 ```
 @Test
-@JUnitPerfTest(threads = 50, durationMs = 125_000, warmUpMs = 10_000, maxExecutionsPerSecond = 11_000)
+@JUnitPerfTest(threads = 50, durationMs = 125_000, rampUpPeriodMs = 2_000, warmUpMs = 10_000, maxExecutionsPerSecond = 11_000)
 public void whenExecuting11Kqps_thenApiShouldNotCrash(){
   ... EXECUTE TIME SENSITIVE TASK ...
 }
@@ -75,7 +75,8 @@ public void whenExecuting11Kqps_thenApiShouldNotCrash(){
 In the example above, the unittest `whenExecuting11Kqps_thenApiShouldNotCrash` will be executed in a loop for 
 125 secs (125,000ms) using 50 threads. 
 
-The executions will be rate limited to 11K loop executions per second. 
+The executions will be rate limited to 11K loop executions per second. The execution rate will ramp up smoothly to 11K 
+over a period of 2 seconds (rampUpPeriodMs). 
 
 No statistical data will be captured during the warm up period (10 seconds - 10,000ms) 
 
@@ -129,7 +130,7 @@ Next add the `JUnitPerfTest` annotation to the unit test you would like to conve
 
 ```
 @Test
-@JUnitPerfTest(durationMs = 125_000, warmUpMs = 10_000, maxExecutionsPerSecond = 1000)
+@JUnitPerfTest(durationMs = 125_000, rampUpPeriodMs = 2_000, warmUpMs = 10_000, maxExecutionsPerSecond = 1000)
 public void whenExecuting1Kqps_thenApiShouldNotCrash(){
    TestContext context = rule.newContext();
    threadPool.submit( () -> {
@@ -145,7 +146,8 @@ public void whenExecuting1Kqps_thenApiShouldNotCrash(){
 In the example above, the unittest `whenExecuting1Kqps_thenApiShouldNotCrash` will be executed in a loop for 
 125 secs (125,000ms). 
 
-Async tasks will be rate limited to 1,000 task submissions per second.
+Async tasks will be rate limited to 1,000 task submissions per second. The execution rate will ramp up smoothly to 1K 
+over a period of 2 seconds (rampUpPeriodMs).
 
 The `TestContext` instance is used to capture latency and error stats during the duration of the test. A timer is started when
 `rule.newContext()` is called and the timer is stopped when either `context.success()` or `context.fail()` is called.
@@ -208,6 +210,7 @@ More information on statistic calculations can be found [here](#statistics)
 | durationMs             | Total time to run the test in millisecs (ms) (includes warmup period)                                                             |      60,000    |
 | warmUpMs               | Warm up period in ms, test logic will be executed during warm up, but results will not be considered during statistics evaluation |        0       |
 | maxExecutionsPerSecond | Sets the maximum number of iteration per second (disabled by default)                                                             |       -1       |
+| rampUpPeriodMs         | Framework ramps up its executions per second smoothly over the duration of this period (disabled by default)                      |        0       |
 
 <br />
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'jacoco'
 group = 'com.github.noconnor'
 sourceCompatibility = 1.8
 // http://semver.org/
-version = '1.12.0'
+version = '1.13.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/github/noconnor/junitperf/JUnitPerfTest.java
+++ b/src/main/java/com/github/noconnor/junitperf/JUnitPerfTest.java
@@ -22,4 +22,8 @@ public @interface JUnitPerfTest {
   // Default value is no limit
   int maxExecutionsPerSecond() default -1;
 
+  // the duration of the period where the framework ramps up its executions per second,
+  // before reaching its stable (maxExecutionsPerSecond) rate
+  // If maxExecutionsPerSecond is not set, this attribute will have no effect
+  int rampUpPeriodMs() default 0;
 }

--- a/src/main/java/com/github/noconnor/junitperf/data/EvaluationContext.java
+++ b/src/main/java/com/github/noconnor/junitperf/data/EvaluationContext.java
@@ -184,6 +184,7 @@ public class EvaluationContext {
     checkNotNull(testSettings, "Test settings must not be null");
     checkState(testSettings.durationMs() > 0, "DurationMs must be greater than 0ms");
     checkState(testSettings.rampUpPeriodMs() >= 0, "RampUpPeriodMs must be >= 0ms");
+    checkState(testSettings.rampUpPeriodMs() < testSettings.durationMs(), "RampUpPeriodMs must be < DurationMs");
     checkState(testSettings.warmUpMs() >= 0, "WarmUpMs must be >= 0ms");
     checkState(testSettings.warmUpMs() < testSettings.durationMs(), "WarmUpMs must be < DurationMs");
     checkState(testSettings.threads() > 0, "Threads must be > 0");

--- a/src/main/java/com/github/noconnor/junitperf/data/EvaluationContext.java
+++ b/src/main/java/com/github/noconnor/junitperf/data/EvaluationContext.java
@@ -33,6 +33,8 @@ public class EvaluationContext {
   @Getter
   private int configuredRateLimit;
   @Getter
+  private int configuredRampUpPeriodMs;
+  @Getter
   private long startTimeNs;
   @Getter
   private boolean isAsyncEvaluation;
@@ -114,6 +116,7 @@ public class EvaluationContext {
     configuredDuration = testSettings.durationMs();
     configuredWarmUp = testSettings.warmUpMs();
     configuredRateLimit = testSettings.maxExecutionsPerSecond();
+    configuredRampUpPeriodMs = testSettings.rampUpPeriodMs();
   }
 
   public void loadRequirements(JUnitPerfTestRequirement requirements) {
@@ -180,6 +183,7 @@ public class EvaluationContext {
   private void validateTestSettings(JUnitPerfTest testSettings) {
     checkNotNull(testSettings, "Test settings must not be null");
     checkState(testSettings.durationMs() > 0, "DurationMs must be greater than 0ms");
+    checkState(testSettings.rampUpPeriodMs() >= 0, "RampUpPeriodMs must be >= 0ms");
     checkState(testSettings.warmUpMs() >= 0, "WarmUpMs must be >= 0ms");
     checkState(testSettings.warmUpMs() < testSettings.durationMs(), "WarmUpMs must be < DurationMs");
     checkState(testSettings.threads() > 0, "Threads must be > 0");

--- a/src/main/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGenerator.java
+++ b/src/main/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGenerator.java
@@ -31,6 +31,7 @@ public class ConsoleReportGenerator implements ReportGenerator {
       log.info("");
       log.info("Thread Count: {}", context.getConfiguredThreads());
       log.info("Warm up:      {} ms", context.getConfiguredWarmUp());
+      log.info("Ramp up:      {} ms", context.getConfiguredRampUpPeriodMs());
       log.info("");
       log.info("Execution time: {} ms", context.getConfiguredDuration());
       log.info("Throughput:     {}/s (Required: {}/s) - {}",

--- a/src/main/java/com/github/noconnor/junitperf/statements/PerformanceEvaluationStatement.java
+++ b/src/main/java/com/github/noconnor/junitperf/statements/PerformanceEvaluationStatement.java
@@ -16,6 +16,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.util.concurrent.RateLimiter.create;
 import static java.lang.String.format;
 import static java.util.Objects.nonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -42,7 +43,7 @@ public class PerformanceEvaluationStatement extends Statement {
     this.baseStatement = baseStatement;
     this.statistics = statistics;
     this.threadFactory = nonNull(threadFactory) ? threadFactory : FACTORY;
-    this.rateLimiter = context.getConfiguredRateLimit() > 0 ? create(context.getConfiguredRateLimit()) : null;
+    this.rateLimiter = context.getConfiguredRateLimit() > 0 ? createRateLimiter(context) : null;
     this.listener = listener;
   }
 
@@ -82,5 +83,10 @@ public class PerformanceEvaluationStatement extends Statement {
       assertThat(format("%dth Percentile has not achieved required threshold", percentile), isAchieved, is(true));
     });
   }
+
+  private RateLimiter createRateLimiter(final EvaluationContext context) {
+    return create(context.getConfiguredRateLimit(), context.getConfiguredRampUpPeriodMs(), MILLISECONDS);
+  }
+
 
 }

--- a/src/main/resources/templates/report.twig
+++ b/src/main/resources/templates/report.twig
@@ -121,6 +121,11 @@
                             <td align='right'>{{ number_format(context.configuredWarmUp, 0, ".", ",") }} ms</td>
                             <td align='right'></td>
                         </tr>
+                        <tr>
+                            <th align='right' valign='top'>Ramp up:</th>
+                            <td align='right'>{{ number_format(context.configuredRampUpPeriodMs, 0, ".", ",") }} ms</td>
+                            <td align='right'></td>
+                        </tr>
                         <tr><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>
                         <tr valign='top'>
                             <th>&nbsp;</th>

--- a/src/test/examples/com/github/noconnor/junitperf/examples/ExampleSuccessTests.java
+++ b/src/test/examples/com/github/noconnor/junitperf/examples/ExampleSuccessTests.java
@@ -16,7 +16,7 @@ public class ExampleSuccessTests {
   public JUnitPerfRule perfRule = new JUnitPerfRule();
 
   @Test
-  @JUnitPerfTest(threads = 10, durationMs = 10_000, warmUpMs = 1_000, maxExecutionsPerSecond = 100)
+  @JUnitPerfTest(threads = 10, durationMs = 10_000, warmUpMs = 1_000, rampUpPeriodMs = 2_000, maxExecutionsPerSecond = 100)
   public void whenNoRequirementsArePresent_thenTestShouldAlwaysPass() throws IOException {
     try (Socket socket = new Socket()) {
       socket.connect(new InetSocketAddress("www.google.com", 80), 1000);

--- a/src/test/java/com/github/noconnor/junitperf/data/EvaluationContextTest.java
+++ b/src/test/java/com/github/noconnor/junitperf/data/EvaluationContextTest.java
@@ -54,6 +54,7 @@ public class EvaluationContextTest extends BaseTest {
     assertThat(context.getConfiguredRateLimit(), is(perfTestAnnotation.maxExecutionsPerSecond()));
     assertThat(context.getConfiguredThreads(), is(perfTestAnnotation.threads()));
     assertThat(context.getConfiguredWarmUp(), is(perfTestAnnotation.warmUpMs()));
+    assertThat(context.getConfiguredRampUpPeriodMs(), is(perfTestAnnotation.rampUpPeriodMs()));
   }
 
   @Test
@@ -62,6 +63,12 @@ public class EvaluationContextTest extends BaseTest {
     expectValidationError("DurationMs must be greater than 0ms");
     when(perfTestAnnotation.durationMs()).thenReturn(-50);
     expectValidationError("DurationMs must be greater than 0ms");
+  }
+
+  @Test
+  public void whenLoadingJUnitPerfTestSettings_thenRampUpMsShouldBeGreaterThanZero() {
+    when(perfTestAnnotation.rampUpPeriodMs()).thenReturn(-9);
+    expectValidationError("RampUpPeriodMs must be >= 0ms");
   }
 
   @Test
@@ -318,6 +325,7 @@ public class EvaluationContextTest extends BaseTest {
     when(perfTestAnnotation.maxExecutionsPerSecond()).thenReturn(1_000);
     when(perfTestAnnotation.threads()).thenReturn(50);
     when(perfTestAnnotation.warmUpMs()).thenReturn(5);
+    when(perfTestAnnotation.rampUpPeriodMs()).thenReturn(40);
   }
 
   private void initialisePerfTestRequirementAnnotation() {

--- a/src/test/java/com/github/noconnor/junitperf/data/EvaluationContextTest.java
+++ b/src/test/java/com/github/noconnor/junitperf/data/EvaluationContextTest.java
@@ -72,6 +72,13 @@ public class EvaluationContextTest extends BaseTest {
   }
 
   @Test
+  public void whenLoadingJUnitPerfTestSettings_thenRampUpMsShouldBeLessThanTestDuration() {
+    when(perfTestAnnotation.rampUpPeriodMs()).thenReturn(60);
+    when(perfTestAnnotation.durationMs()).thenReturn(50);
+    expectValidationError("RampUpPeriodMs must be < DurationMs");
+  }
+
+  @Test
   public void whenLoadingJUnitPerfTestSettings_thenWarmUpMsShouldBeSensible() {
     when(perfTestAnnotation.warmUpMs()).thenReturn(-9);
     expectValidationError("WarmUpMs must be >= 0ms");
@@ -325,7 +332,7 @@ public class EvaluationContextTest extends BaseTest {
     when(perfTestAnnotation.maxExecutionsPerSecond()).thenReturn(1_000);
     when(perfTestAnnotation.threads()).thenReturn(50);
     when(perfTestAnnotation.warmUpMs()).thenReturn(5);
-    when(perfTestAnnotation.rampUpPeriodMs()).thenReturn(40);
+    when(perfTestAnnotation.rampUpPeriodMs()).thenReturn(4);
   }
 
   private void initialisePerfTestRequirementAnnotation() {

--- a/src/test/java/com/github/noconnor/junitperf/data/NoOpTestContextTest.java
+++ b/src/test/java/com/github/noconnor/junitperf/data/NoOpTestContextTest.java
@@ -1,0 +1,24 @@
+package com.github.noconnor.junitperf.data;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class NoOpTestContextTest {
+
+  private NoOpTestContext context;
+
+  @Before
+  public void setup() {
+    context = new NoOpTestContext();
+  }
+
+  @Test
+  public void whenCallingSuccess_thenNoExceptionsShouldBeThrown() {
+    context.success();
+  }
+
+  @Test
+  public void whenCallingFail_thenNoExceptionsShouldBeThrown() {
+    context.fail();
+  }
+}

--- a/src/test/java/com/github/noconnor/junitperf/reporting/BaseReportGeneratorTest.java
+++ b/src/test/java/com/github/noconnor/junitperf/reporting/BaseReportGeneratorTest.java
@@ -136,6 +136,7 @@ public class BaseReportGeneratorTest extends BaseTest {
   protected void initialisePerfTestAnnotationMock() {
     when(perfTestAnnotationMock.durationMs()).thenReturn(10_000);
     when(perfTestAnnotationMock.warmUpMs()).thenReturn(100);
+    when(perfTestAnnotationMock.rampUpPeriodMs()).thenReturn(50);
     when(perfTestAnnotationMock.threads()).thenReturn(50);
     when(perfTestAnnotationMock.maxExecutionsPerSecond()).thenReturn(11_000);
   }

--- a/src/test/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGeneratorTest.java
+++ b/src/test/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGeneratorTest.java
@@ -12,7 +12,7 @@ public class ConsoleReportGeneratorTest extends BaseReportGeneratorTest {
   private ConsoleReportGenerator reportGenerator;
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     reportGenerator = new ConsoleReportGenerator();
     initialisePerfTestAnnotationMock();
     initialisePerfTestRequirementAnnotationMock();

--- a/src/test/resources/html/example_all_failed_report.html
+++ b/src/test/resources/html/example_all_failed_report.html
@@ -521,6 +521,11 @@
                             <td align='right'>100 ms</td>
                             <td align='right'></td>
                         </tr>
+                        <tr>
+                            <th align='right' valign='top'>Ramp up:</th>
+                            <td align='right'>50 ms</td>
+                            <td align='right'></td>
+                        </tr>
                         <tr><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>
                         <tr valign='top'>
                             <th>&nbsp;</th>
@@ -1075,6 +1080,11 @@
                         <tr>
                             <th align='right' valign='top'>Warm up:</th>
                             <td align='right'>100 ms</td>
+                            <td align='right'></td>
+                        </tr>
+                        <tr>
+                            <th align='right' valign='top'>Ramp up:</th>
+                            <td align='right'>50 ms</td>
                             <td align='right'></td>
                         </tr>
                         <tr><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>

--- a/src/test/resources/html/example_all_passed_report.html
+++ b/src/test/resources/html/example_all_passed_report.html
@@ -521,6 +521,11 @@
                             <td align='right'>100 ms</td>
                             <td align='right'></td>
                         </tr>
+                        <tr>
+                            <th align='right' valign='top'>Ramp up:</th>
+                            <td align='right'>50 ms</td>
+                            <td align='right'></td>
+                        </tr>
                         <tr><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>
                         <tr valign='top'>
                             <th>&nbsp;</th>
@@ -1075,6 +1080,11 @@
                         <tr>
                             <th align='right' valign='top'>Warm up:</th>
                             <td align='right'>100 ms</td>
+                            <td align='right'></td>
+                        </tr>
+                        <tr>
+                            <th align='right' valign='top'>Ramp up:</th>
+                            <td align='right'>50 ms</td>
                             <td align='right'></td>
                         </tr>
                         <tr><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>

--- a/src/test/resources/html/example_mixed_report.html
+++ b/src/test/resources/html/example_mixed_report.html
@@ -521,6 +521,11 @@
                             <td align='right'>100 ms</td>
                             <td align='right'></td>
                         </tr>
+                        <tr>
+                            <th align='right' valign='top'>Ramp up:</th>
+                            <td align='right'>50 ms</td>
+                            <td align='right'></td>
+                        </tr>
                         <tr><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>
                         <tr valign='top'>
                             <th>&nbsp;</th>
@@ -1075,6 +1080,11 @@
                         <tr>
                             <th align='right' valign='top'>Warm up:</th>
                             <td align='right'>100 ms</td>
+                            <td align='right'></td>
+                        </tr>
+                        <tr>
+                            <th align='right' valign='top'>Ramp up:</th>
+                            <td align='right'>50 ms</td>
                             <td align='right'></td>
                         </tr>
                         <tr><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>

--- a/src/test/resources/html/example_some_failures_report.html
+++ b/src/test/resources/html/example_some_failures_report.html
@@ -515,6 +515,11 @@
                             <td align='right'>100 ms</td>
                             <td align='right'></td>
                         </tr>
+                        <tr>
+                            <th align='right' valign='top'>Ramp up:</th>
+                            <td align='right'>50 ms</td>
+                            <td align='right'></td>
+                        </tr>
                         <tr><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr>
                         <tr valign='top'>
                             <th>&nbsp;</th>


### PR DESCRIPTION
Fixes #7 Add ramp up attribute

## Proposed Changes

  - Adding attribute to allow clients to control the rate at which the test ramps up to max executions per second
