### PR TITLE
Refactoring reporters to allow sharing across multiple JUnitPerfRule …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'jacoco'
 group = 'com.github.noconnor'
 sourceCompatibility = 1.8
 // http://semver.org/
-version = '1.13.1'
+version = '1.14.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/github/noconnor/junitperf/data/EvaluationContext.java
+++ b/src/main/java/com/github/noconnor/junitperf/data/EvaluationContext.java
@@ -6,6 +6,8 @@ import com.github.noconnor.junitperf.datetime.DatetimeUtils;
 import com.github.noconnor.junitperf.statistics.StatisticsCalculator;
 import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
+
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.tuple.ImmutablePair;

--- a/src/main/java/com/github/noconnor/junitperf/data/EvaluationContext.java
+++ b/src/main/java/com/github/noconnor/junitperf/data/EvaluationContext.java
@@ -6,8 +6,6 @@ import com.github.noconnor.junitperf.datetime.DatetimeUtils;
 import com.github.noconnor.junitperf.statistics.StatisticsCalculator;
 import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
-
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.tuple.ImmutablePair;

--- a/src/main/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGenerator.java
+++ b/src/main/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGenerator.java
@@ -2,13 +2,14 @@ package com.github.noconnor.junitperf.reporting.providers;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import com.github.noconnor.junitperf.data.EvaluationContext;
 import com.github.noconnor.junitperf.reporting.ReportGenerator;
-import com.github.noconnor.junitperf.statistics.StatisticsCalculator;
+import com.google.common.collect.Sets;
 
 import static com.github.noconnor.junitperf.reporting.utils.FormatterUtils.format;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @Slf4j
 public class ConsoleReportGenerator implements ReportGenerator {
@@ -16,48 +17,60 @@ public class ConsoleReportGenerator implements ReportGenerator {
   private static final String PASSED = "PASSED";
   private static final String FAILED = "FAILED!!";
 
+  private final Set<EvaluationContext> history;
+
+  public ConsoleReportGenerator() {
+    this.history = new HashSet<>();
+  }
+
   @Override
   public void generateReport(Set<EvaluationContext> testContexts) {
-    testContexts.forEach(context -> {
-      String throughputStatus = context.isThroughputAchieved() ? PASSED : FAILED;
-      String errorRateStatus = context.isErrorThresholdAchieved() ? PASSED : FAILED;
-
-      log.info("Test Name:    {}", context.getTestName());
-      log.info("Started at:   {}", context.getStartTime());
-      log.info("Invocations:  {}", context.getEvaluationCount());
-      log.info("  - Success:  {}", context.getEvaluationCount() - context.getErrorCount());
-      log.info("  - Errors:   {}", context.getErrorCount());
-      log.info("  - Errors:   {}% - {}", context.getErrorPercentage(), errorRateStatus);
-      log.info("");
-      log.info("Thread Count: {}", context.getConfiguredThreads());
-      log.info("Warm up:      {} ms", context.getConfiguredWarmUp());
-      log.info("Ramp up:      {} ms", context.getConfiguredRampUpPeriodMs());
-      log.info("");
-      log.info("Execution time: {} ms", context.getConfiguredDuration());
-      log.info("Throughput:     {}/s (Required: {}/s) - {}",
-        context.getThroughputQps(),
-        context.getRequiredThroughput(),
-        throughputStatus);
-      log.info("Min. latency:   {} ms (Required: {}ms) - {}",
-        context.getMinLatencyMs(),
-        format(context.getRequiredMinLatency()));
-      log.info("Max. latency:    {} ms (Required: {}ms) - {}",
-        context.getMaxLatencyMs(),
-        format(context.getRequiredMaxLatency()));
-      log.info("Ave. latency:    {} ms (Required: {}ms) - {}",
-        context.getMeanLatencyMs(),
-        format(context.getRequiredMeanLatency()));
-      context.getRequiredPercentiles().forEach((percentile, threshold) -> {
-        String percentileStatus = context.getPercentileResults().get(percentile) ? PASSED : FAILED;
-        log.info("{}:    {}ms (Required: {} ms) - {}",
-          percentile,
-          context.getLatencyPercentileMs(percentile),
-          format(threshold),
-          percentileStatus);
-      });
-      log.info("");
-      log.info("");
+    // Only output the difference - new contexts
+    Sets.difference(testContexts, history).forEach( c -> {
+      history.add(c);
+      updateReport(c);
     });
+  }
+
+  public void updateReport(EvaluationContext context) {
+    String throughputStatus = context.isThroughputAchieved() ? PASSED : FAILED;
+    String errorRateStatus = context.isErrorThresholdAchieved() ? PASSED : FAILED;
+
+    log.info("Test Name:    {}", context.getTestName());
+    log.info("Started at:   {}", context.getStartTime());
+    log.info("Invocations:  {}", context.getEvaluationCount());
+    log.info("  - Success:  {}", context.getEvaluationCount() - context.getErrorCount());
+    log.info("  - Errors:   {}", context.getErrorCount());
+    log.info("  - Errors:   {}% - {}", context.getErrorPercentage(), errorRateStatus);
+    log.info("");
+    log.info("Thread Count: {}", context.getConfiguredThreads());
+    log.info("Warm up:      {} ms", context.getConfiguredWarmUp());
+    log.info("Ramp up:      {} ms", context.getConfiguredRampUpPeriodMs());
+    log.info("");
+    log.info("Execution time: {} ms", context.getConfiguredDuration());
+    log.info("Throughput:     {}/s (Required: {}/s) - {}",
+      context.getThroughputQps(),
+      context.getRequiredThroughput(),
+      throughputStatus);
+    log.info("Min. latency:   {} ms (Required: {}ms) - {}",
+      context.getMinLatencyMs(),
+      format(context.getRequiredMinLatency()));
+    log.info("Max. latency:    {} ms (Required: {}ms) - {}",
+      context.getMaxLatencyMs(),
+      format(context.getRequiredMaxLatency()));
+    log.info("Ave. latency:    {} ms (Required: {}ms) - {}",
+      context.getMeanLatencyMs(),
+      format(context.getRequiredMeanLatency()));
+    context.getRequiredPercentiles().forEach((percentile, threshold) -> {
+      String percentileStatus = context.getPercentileResults().get(percentile) ? PASSED : FAILED;
+      log.info("{}:    {}ms (Required: {} ms) - {}",
+        percentile,
+        context.getLatencyPercentileMs(percentile),
+        format(threshold),
+        percentileStatus);
+    });
+    log.info("");
+    log.info("");
   }
 
   @Override

--- a/src/main/java/com/github/noconnor/junitperf/reporting/providers/CsvReportGenerator.java
+++ b/src/main/java/com/github/noconnor/junitperf/reporting/providers/CsvReportGenerator.java
@@ -8,6 +8,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -26,20 +28,26 @@ public class CsvReportGenerator implements ReportGenerator {
   private static final String DEFAULT_REPORT_PATH = getProperty("user.dir") + "/build/reports/junitperf_report.csv";
 
   private final String reportPath;
+  private final Set<EvaluationContext> history;
 
-  public CsvReportGenerator() {this(DEFAULT_REPORT_PATH);}
+  public CsvReportGenerator() {
+    this(DEFAULT_REPORT_PATH);
+  }
 
   @SuppressWarnings("WeakerAccess")
-  public CsvReportGenerator(String reportPath) {this.reportPath = reportPath;}
+  public CsvReportGenerator(String reportPath) {
+    this.reportPath = reportPath;
+    this.history = new LinkedHashSet<>();
+  }
 
   @Override
   public void generateReport(final Set<EvaluationContext> testContexts) {
-
+    history.addAll(testContexts);
     try (BufferedWriter writer = newBufferedWriter()) {
 
       writer.write(buildHeader());
       writer.newLine();
-      testContexts.forEach(context -> {
+      history.forEach(context -> {
 
         String record = String.format("%s,%d,%d,%d,%.4f,%.4f,%.4f,%s",
           context.getTestName(),

--- a/src/main/java/com/github/noconnor/junitperf/reporting/providers/HtmlReportGenerator.java
+++ b/src/main/java/com/github/noconnor/junitperf/reporting/providers/HtmlReportGenerator.java
@@ -6,8 +6,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import org.jtwig.JtwigModel;
 import org.jtwig.JtwigTemplate;
 import com.github.noconnor.junitperf.data.EvaluationContext;
@@ -22,18 +23,28 @@ public class HtmlReportGenerator implements ReportGenerator {
   private static final String REPORT_TEMPLATE = "templates/report.twig";
 
   private final String reportPath;
+  private final Set<EvaluationContext> history;
 
-  public HtmlReportGenerator() {this(DEFAULT_REPORT_PATH);}
+  public HtmlReportGenerator() {
+    this(DEFAULT_REPORT_PATH);
+  }
 
   @SuppressWarnings("WeakerAccess")
-  public HtmlReportGenerator(String reportPath) {this.reportPath = reportPath;}
+  public HtmlReportGenerator(String reportPath) {
+    this.reportPath = reportPath;
+    this.history = new LinkedHashSet<>();
+  }
 
   @Override
   public void generateReport(Set<EvaluationContext> testContexts) {
+    history.addAll(testContexts);
+    renderTemplate();
+  }
+
+  private void renderTemplate() {
     Path outputPath = Paths.get(reportPath);
     JtwigTemplate template = JtwigTemplate.classpathTemplate(REPORT_TEMPLATE);
-    JtwigModel model = JtwigModel.newModel()
-      .with("contextData", testContexts);
+    JtwigModel model = JtwigModel.newModel().with("contextData", history);
     try {
       Files.createDirectories(outputPath.getParent());
       log.info("Rendering report to: " + outputPath);

--- a/src/test/examples/com/github/noconnor/junitperf/examples/ExampleCommonReporter.java
+++ b/src/test/examples/com/github/noconnor/junitperf/examples/ExampleCommonReporter.java
@@ -1,0 +1,55 @@
+package com.github.noconnor.junitperf.examples;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import com.github.noconnor.junitperf.JUnitPerfRule;
+import com.github.noconnor.junitperf.JUnitPerfTest;
+import com.github.noconnor.junitperf.JUnitPerfTestRequirement;
+import com.github.noconnor.junitperf.reporting.providers.HtmlReportGenerator;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+  ExampleCommonReporter.TestClassOne.class,
+  ExampleCommonReporter.TestClassTwo.class
+})
+public class ExampleCommonReporter {
+
+  // Both test classes should report to the same HTML file
+  private static final HtmlReportGenerator REPORTER = new HtmlReportGenerator();
+
+  public static class TestClassOne {
+    @Rule
+    public JUnitPerfRule perfRule = new JUnitPerfRule(REPORTER);
+
+    @Test
+    @JUnitPerfTest(threads = 10, durationMs = 10_000, warmUpMs = 1_000, rampUpPeriodMs = 2_000, maxExecutionsPerSecond = 100)
+    public void whenNoRequirementsArePresent_thenTestShouldAlwaysPass() throws IOException {
+      try (Socket socket = new Socket()) {
+        socket.connect(new InetSocketAddress("www.google.com", 80), 1000);
+        assertTrue(socket.isConnected());
+      }
+    }
+  }
+
+  public static class TestClassTwo {
+    @Rule
+    public JUnitPerfRule perfRule = new JUnitPerfRule(REPORTER);
+
+    @Test(expected = AssertionError.class)
+    @JUnitPerfTest(threads = 1, durationMs = 1_000, maxExecutionsPerSecond = 1_000)
+    @JUnitPerfTestRequirement(executionsPerSec = 10_000)
+    public void whenThroughputRequirementIsNotMet_thenTestShouldFail() throws InterruptedException {
+      // Mock some processing logic
+      Thread.sleep(1);
+    }
+  }
+
+
+}

--- a/src/test/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGeneratorTest.java
+++ b/src/test/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGeneratorTest.java
@@ -1,8 +1,10 @@
 package com.github.noconnor.junitperf.reporting.providers;
 
 import java.io.IOException;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
+import com.github.noconnor.junitperf.data.EvaluationContext;
 import com.github.noconnor.junitperf.reporting.BaseReportGeneratorTest;
 
 import static org.junit.Assert.assertNull;
@@ -19,27 +21,34 @@ public class ConsoleReportGeneratorTest extends BaseReportGeneratorTest {
   }
 
   @Test
-  public void whenGeneratingAReport_andAllTestsFailed_thenAppropriateReportShouldBeGenerated() throws IOException {
+  public void whenGeneratingAReport_andAllTestsFailed_thenAppropriateReportShouldBeGenerated() {
     reportGenerator.generateReport(generateAllFailureOrderedContexts());
   }
 
   @Test
-  public void whenGeneratingAReport_andAllTestsPass_thenAppropriateReportShouldBeGenerated() throws IOException {
+  public void whenGeneratingAReport_andAllTestsPass_thenAppropriateReportShouldBeGenerated() {
     reportGenerator.generateReport(generateAllPassedOrderedContexts());
   }
 
   @Test
-  public void whenGeneratingAReport_andTestsContainsAMixOfPassAndFailures_thenAppropriateReportShouldBeGenerated() throws IOException {
+  public void whenGeneratingAReport_andTestsContainsAMixOfPassAndFailures_thenAppropriateReportShouldBeGenerated() {
     reportGenerator.generateReport(generateMixedOrderedContexts());
   }
 
   @Test
-  public void whenGeneratingAReport_andTestsContainsSomeFailures_thenAppropriateReportShouldBeGenerated() throws IOException {
+  public void whenGeneratingAReport_andTestsContainsSomeFailures_thenAppropriateReportShouldBeGenerated() {
     reportGenerator.generateReport(generateSomeFailuresContext());
   }
 
   @Test
-  public void whenCallingGetReportPath_thenNullShouldBeReturned() throws IOException {
+  public void whenGeneratingAReport_andGenerateIsCalledMultipleTimes_thenOnlyNewResultsShouldBePrinted() {
+    Set<EvaluationContext> contexts = generateSomeFailuresContext();
+    reportGenerator.generateReport(contexts);
+    reportGenerator.generateReport(contexts);
+  }
+
+  @Test
+  public void whenCallingGetReportPath_thenNullShouldBeReturned() {
     assertNull(reportGenerator.getReportPath());
   }
 }


### PR DESCRIPTION
…instances

Fixes #30 

## Proposed Changes

  - Refactoring to allow sharing of reporters across JUnitPerfRule instances
  - Reporters now keep track of history when generating reports
