### PR TITLE
Adding fix for console reporter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'jacoco'
 group = 'com.github.noconnor'
 sourceCompatibility = 1.8
 // http://semver.org/
-version = '1.14.0'
+version = '1.15.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/github/noconnor/junitperf/JUnitPerfRule.java
+++ b/src/main/java/com/github/noconnor/junitperf/JUnitPerfRule.java
@@ -2,8 +2,7 @@ package com.github.noconnor.junitperf;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import org.junit.rules.TestRule;
@@ -19,6 +18,7 @@ import com.github.noconnor.junitperf.statistics.providers.DescriptiveStatisticsC
 
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
+import static com.google.common.collect.Sets.newLinkedHashSet;
 import static java.lang.System.nanoTime;
 import static java.util.Objects.nonNull;
 
@@ -26,7 +26,7 @@ import static java.util.Objects.nonNull;
 @SuppressWarnings("WeakerAccess")
 public class JUnitPerfRule implements TestRule {
 
-  static final Map<Class, Set<EvaluationContext>> ACTIVE_CONTEXTS = newHashMap();
+  static final Map<Class, LinkedHashSet<EvaluationContext>> ACTIVE_CONTEXTS = newHashMap();
 
   private final Set<ReportGenerator> reporters;
 
@@ -64,7 +64,7 @@ public class JUnitPerfRule implements TestRule {
       context.loadRequirements(requirementsAnnotation);
 
       // Group test contexts by test class
-      ACTIVE_CONTEXTS.putIfAbsent(description.getTestClass(), newHashSet());
+      ACTIVE_CONTEXTS.putIfAbsent(description.getTestClass(), newLinkedHashSet());
       ACTIVE_CONTEXTS.get(description.getTestClass()).add(context);
 
       activeStatement = perEvalBuilder.baseStatement(base)

--- a/src/main/java/com/github/noconnor/junitperf/reporting/ReportGenerator.java
+++ b/src/main/java/com/github/noconnor/junitperf/reporting/ReportGenerator.java
@@ -1,11 +1,11 @@
 package com.github.noconnor.junitperf.reporting;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
 import com.github.noconnor.junitperf.data.EvaluationContext;
 
 public interface ReportGenerator {
 
-  void generateReport(Set<EvaluationContext> testContexts);
+  void generateReport(LinkedHashSet<EvaluationContext> testContexts);
 
   String getReportPath();
 

--- a/src/main/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGenerator.java
+++ b/src/main/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGenerator.java
@@ -2,12 +2,10 @@ package com.github.noconnor.junitperf.reporting.providers;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import com.github.noconnor.junitperf.data.EvaluationContext;
 import com.github.noconnor.junitperf.reporting.ReportGenerator;
-import com.google.common.collect.Sets;
 
 import static com.github.noconnor.junitperf.reporting.utils.FormatterUtils.format;
 
@@ -17,19 +15,16 @@ public class ConsoleReportGenerator implements ReportGenerator {
   private static final String PASSED = "PASSED";
   private static final String FAILED = "FAILED!!";
 
-  private final Set<EvaluationContext> history;
-
-  public ConsoleReportGenerator() {
-    this.history = new HashSet<>();
-  }
 
   @Override
-  public void generateReport(Set<EvaluationContext> testContexts) {
-    // Only output the difference - new contexts
-    Sets.difference(testContexts, history).forEach( c -> {
-      history.add(c);
-      updateReport(c);
-    });
+  public void generateReport(LinkedHashSet<EvaluationContext> testContexts) {
+    // Only output the last context
+    final Iterator<EvaluationContext> itr = testContexts.iterator();
+    EvaluationContext context = itr.next();
+    while (itr.hasNext()) {
+      context = itr.next();
+    }
+    updateReport(context);
   }
 
   public void updateReport(EvaluationContext context) {

--- a/src/main/java/com/github/noconnor/junitperf/reporting/providers/CsvReportGenerator.java
+++ b/src/main/java/com/github/noconnor/junitperf/reporting/providers/CsvReportGenerator.java
@@ -8,18 +8,15 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import com.github.noconnor.junitperf.data.EvaluationContext;
 import com.github.noconnor.junitperf.reporting.ReportGenerator;
 import com.google.common.base.Joiner;
 
 import static java.lang.System.getProperty;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
 
 @Slf4j
@@ -41,7 +38,7 @@ public class CsvReportGenerator implements ReportGenerator {
   }
 
   @Override
-  public void generateReport(final Set<EvaluationContext> testContexts) {
+  public void generateReport(LinkedHashSet<EvaluationContext> testContexts) {
     history.addAll(testContexts);
     try (BufferedWriter writer = newBufferedWriter()) {
 

--- a/src/main/java/com/github/noconnor/junitperf/reporting/providers/HtmlReportGenerator.java
+++ b/src/main/java/com/github/noconnor/junitperf/reporting/providers/HtmlReportGenerator.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import org.jtwig.JtwigModel;
@@ -36,7 +35,7 @@ public class HtmlReportGenerator implements ReportGenerator {
   }
 
   @Override
-  public void generateReport(Set<EvaluationContext> testContexts) {
+  public void generateReport(LinkedHashSet<EvaluationContext> testContexts) {
     history.addAll(testContexts);
     renderTemplate();
   }

--- a/src/test/examples/com/github/noconnor/junitperf/examples/ExampleCommonReporter.java
+++ b/src/test/examples/com/github/noconnor/junitperf/examples/ExampleCommonReporter.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 })
 public class ExampleCommonReporter {
 
-  // Both test classes should report to the same HTML file
+  // Both ExampleConsoleReporter classes should report to the same HTML file
   private static final HtmlReportGenerator REPORTER = new HtmlReportGenerator();
 
   public static class TestClassOne {

--- a/src/test/examples/com/github/noconnor/junitperf/examples/ExampleCommonReporter.java
+++ b/src/test/examples/com/github/noconnor/junitperf/examples/ExampleCommonReporter.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 })
 public class ExampleCommonReporter {
 
-  // Both ExampleConsoleReporter classes should report to the same HTML file
+  // Both test classes should report to the same HTML file
   private static final HtmlReportGenerator REPORTER = new HtmlReportGenerator();
 
   public static class TestClassOne {

--- a/src/test/examples/com/github/noconnor/junitperf/examples/ExampleConsoleReporter.java
+++ b/src/test/examples/com/github/noconnor/junitperf/examples/ExampleConsoleReporter.java
@@ -1,0 +1,31 @@
+package com.github.noconnor.junitperf.examples;
+
+import org.junit.Rule;
+import org.junit.Test;
+import com.github.noconnor.junitperf.JUnitPerfRule;
+import com.github.noconnor.junitperf.JUnitPerfTest;
+import com.github.noconnor.junitperf.reporting.providers.ConsoleReportGenerator;
+
+public class ExampleConsoleReporter {
+
+    @Rule
+    public JUnitPerfRule jUnitPerfRule = new JUnitPerfRule(new ConsoleReportGenerator());
+
+    @Test
+    @JUnitPerfTest(threads = 1, warmUpMs = 1_000, durationMs = 2_000)
+    public void test1() throws InterruptedException {
+      Thread.sleep(10);
+    }
+
+    @Test
+    @JUnitPerfTest(threads = 1, warmUpMs = 1_000, durationMs = 2_000)
+    public void test2() throws InterruptedException {
+      Thread.sleep(10);
+    }
+
+    @Test
+    @JUnitPerfTest(threads = 1, warmUpMs = 1_000, durationMs = 2_000)
+    public void test3() throws InterruptedException {
+      Thread.sleep(10);
+    }
+}

--- a/src/test/java/com/github/noconnor/junitperf/JUnitPerfRuleTest.java
+++ b/src/test/java/com/github/noconnor/junitperf/JUnitPerfRuleTest.java
@@ -1,10 +1,7 @@
 package com.github.noconnor.junitperf;
 
-import com.github.noconnor.junitperf.data.EvaluationContext;
-import com.github.noconnor.junitperf.reporting.ReportGenerator;
-import com.github.noconnor.junitperf.statements.PerformanceEvaluationStatement;
-import com.github.noconnor.junitperf.statements.PerformanceEvaluationStatement.PerformanceEvaluationStatementBuilder;
-import com.github.noconnor.junitperf.statistics.StatisticsCalculator;
+import java.util.LinkedHashSet;
+import java.util.function.Consumer;
 import org.hamcrest.junit.MatcherAssert;
 import org.junit.After;
 import org.junit.Before;
@@ -14,9 +11,11 @@ import org.junit.runners.model.Statement;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-
-import java.util.Set;
-import java.util.function.Consumer;
+import com.github.noconnor.junitperf.data.EvaluationContext;
+import com.github.noconnor.junitperf.reporting.ReportGenerator;
+import com.github.noconnor.junitperf.statements.PerformanceEvaluationStatement;
+import com.github.noconnor.junitperf.statements.PerformanceEvaluationStatement.PerformanceEvaluationStatementBuilder;
+import com.github.noconnor.junitperf.statistics.StatisticsCalculator;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -153,8 +152,8 @@ public class JUnitPerfRuleTest extends BaseTest {
   }
 
   @SuppressWarnings("unchecked")
-  private Set<EvaluationContext> captureReportContexts() {
-    ArgumentCaptor<Set<EvaluationContext>> captor = ArgumentCaptor.forClass(Set.class);
+  private LinkedHashSet<EvaluationContext> captureReportContexts() {
+    ArgumentCaptor<LinkedHashSet<EvaluationContext>> captor = ArgumentCaptor.forClass(LinkedHashSet.class);
     verify(csvReporterMock, atLeastOnce()).generateReport(captor.capture());
     verify(htmlReporterMock, atLeastOnce()).generateReport(captor.capture());
     return captor.getValue();

--- a/src/test/java/com/github/noconnor/junitperf/reporting/BaseReportGeneratorTest.java
+++ b/src/test/java/com/github/noconnor/junitperf/reporting/BaseReportGeneratorTest.java
@@ -8,6 +8,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -158,7 +159,7 @@ public class BaseReportGeneratorTest extends BaseTest {
     }
   }
 
-  protected Set<EvaluationContext> generateAllFailureOrderedContexts() {
+  protected LinkedHashSet<EvaluationContext> generateAllFailureOrderedContexts() {
     EvaluationContext context1 = createdFailedEvaluationContext("unittest1");
     EvaluationContext context2 = createdFailedEvaluationContext("unittest2");
     verifyAllValidationFailed(context1);
@@ -166,7 +167,7 @@ public class BaseReportGeneratorTest extends BaseTest {
     return newLinkedHashSet(newArrayList(context1, context2));
   }
 
-  protected Set<EvaluationContext> generateAllPassedOrderedContexts() {
+  protected LinkedHashSet<EvaluationContext> generateAllPassedOrderedContexts() {
     EvaluationContext context1 = createdSuccessfulEvaluationContext("unittest1");
     EvaluationContext context2 = createdSuccessfulEvaluationContext("unittest2");
     verifyAllValidationPassed(context1);
@@ -174,7 +175,7 @@ public class BaseReportGeneratorTest extends BaseTest {
     return newLinkedHashSet(newArrayList(context1, context2));
   }
 
-  protected Set<EvaluationContext> generateMixedOrderedContexts() {
+  protected LinkedHashSet<EvaluationContext> generateMixedOrderedContexts() {
     EvaluationContext context1 = createdFailedEvaluationContext("unittest1");
     EvaluationContext context2 = createdSuccessfulEvaluationContext("unittest2");
     verifyAllValidationFailed(context1);
@@ -182,7 +183,7 @@ public class BaseReportGeneratorTest extends BaseTest {
     return newLinkedHashSet(newArrayList(context1, context2));
   }
 
-  protected Set<EvaluationContext> generateSomeFailuresContext() {
+  protected LinkedHashSet<EvaluationContext> generateSomeFailuresContext() {
     EvaluationContext context = createdSomeFailuresEvaluationContext("unittest1");
     return newLinkedHashSet(newArrayList(context));
   }

--- a/src/test/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGeneratorTest.java
+++ b/src/test/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGeneratorTest.java
@@ -1,7 +1,6 @@
 package com.github.noconnor.junitperf.reporting.providers;
 
-import java.io.IOException;
-import java.util.Set;
+import java.util.LinkedHashSet;
 import org.junit.Before;
 import org.junit.Test;
 import com.github.noconnor.junitperf.data.EvaluationContext;
@@ -42,7 +41,7 @@ public class ConsoleReportGeneratorTest extends BaseReportGeneratorTest {
 
   @Test
   public void whenGeneratingAReport_andGenerateIsCalledMultipleTimes_thenOnlyNewResultsShouldBePrinted() {
-    Set<EvaluationContext> contexts = generateSomeFailuresContext();
+    LinkedHashSet<EvaluationContext> contexts = generateSomeFailuresContext();
     reportGenerator.generateReport(contexts);
     reportGenerator.generateReport(contexts);
   }


### PR DESCRIPTION
Fixes #50 Duplicate console reporter output

## Proposed Changes

  - Pass ordered hash set of contexts to Reporters.
  - Console reporter updated to output the last entry in the ordered set

