### PR TITLE
Fixing for min/max/mean latency validation

### DIFF
--- a/junit4-examples/build.gradle
+++ b/junit4-examples/build.gradle
@@ -7,5 +7,6 @@ version '1.16.1'
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    testImplementation 'com.github.noconnor:junitperf-junit4:1.16.1'
+    testImplementation project(':junitperf-core')
+    testImplementation project(':junitperf-junit4')
 }

--- a/junit4-examples/build.gradle
+++ b/junit4-examples/build.gradle
@@ -3,9 +3,9 @@ plugins {
 }
 
 group 'com.github.noconnor'
-version '1.16.0'
+version '1.16.1'
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    testImplementation 'com.github.noconnor:junitperf:1.15.0'
+    testImplementation 'com.github.noconnor:junitperf-junit4:1.16.1'
 }

--- a/junit4-examples/src/test/java/com/github/noconnor/junitperf/examples/ExampleSuccessTests.java
+++ b/junit4-examples/src/test/java/com/github/noconnor/junitperf/examples/ExampleSuccessTests.java
@@ -9,7 +9,6 @@ import com.github.noconnor.junitperf.JUnitPerfRule;
 import com.github.noconnor.junitperf.JUnitPerfTest;
 
 import static com.github.noconnor.junitperf.examples.utils.ReportingUtils.newHtmlReporter;
-import static org.junit.Assert.assertTrue;
 
 public class ExampleSuccessTests {
 
@@ -21,7 +20,6 @@ public class ExampleSuccessTests {
   public void whenNoRequirementsArePresent_thenTestShouldAlwaysPass() throws IOException {
     try (Socket socket = new Socket()) {
       socket.connect(new InetSocketAddress("www.google.com", 80), 1000);
-      assertTrue(socket.isConnected());
     }
   }
 }

--- a/junitperf-core/build.gradle
+++ b/junitperf-core/build.gradle
@@ -1,6 +1,6 @@
 
 group 'com.github.noconnor'
-version '1.16.0'
+version '1.16.1'
 
 dependencies {
     implementation "org.apache.commons:commons-lang3:3.4"

--- a/junitperf-core/src/main/java/com/github/noconnor/junitperf/statements/PerformanceEvaluationStatement.java
+++ b/junitperf-core/src/main/java/com/github/noconnor/junitperf/statements/PerformanceEvaluationStatement.java
@@ -76,6 +76,9 @@ public class PerformanceEvaluationStatement implements TestStatement {
   private void assertThresholdsMet() {
     assertThat("Error threshold not achieved", context.isErrorThresholdAchieved(), true);
     assertThat("Test throughput threshold not achieved", context.isThroughputAchieved(), true);
+    assertThat("Test min latency threshold not achieved", context.isMinLatencyAchieved(), true);
+    assertThat("Test max latency threshold not achieved", context.isMaxLatencyAchieved(), true);
+    assertThat("Test mean latency threshold not achieved", context.isMeanLatencyAchieved(), true);
     context.getPercentileResults().forEach((percentile, isAchieved) -> {
       assertThat(format("%dth Percentile has not achieved required threshold", percentile), isAchieved, true);
     });

--- a/junitperf-core/src/test/java/com/github/noconnor/junitperf/statements/PerformanceEvaluationStatementTest.java
+++ b/junitperf-core/src/test/java/com/github/noconnor/junitperf/statements/PerformanceEvaluationStatementTest.java
@@ -124,6 +124,39 @@ public class PerformanceEvaluationStatementTest extends BaseTest {
   }
 
   @Test
+  public void whenEvaluationCompletes_andMinLatencyValidationFails_thenAssertionShouldBeGenerated() throws Throwable {
+    when(contextMock.isMinLatencyAchieved()).thenReturn(false);
+    try {
+      statement.evaluate();
+      fail("Assertion expected during validation");
+    } catch (Error e) {
+      assertThat(e.getMessage(), startsWith("Test min latency threshold not achieved"));
+    }
+  }
+
+  @Test
+  public void whenEvaluationCompletes_andMeanLatencyValidationFails_thenAssertionShouldBeGenerated() throws Throwable {
+    when(contextMock.isMeanLatencyAchieved()).thenReturn(false);
+    try {
+      statement.evaluate();
+      fail("Assertion expected during validation");
+    } catch (Error e) {
+      assertThat(e.getMessage(), startsWith("Test mean latency threshold not achieved"));
+    }
+  }
+
+  @Test
+  public void whenEvaluationCompletes_andMaxLatencyValidationFails_thenAssertionShouldBeGenerated() throws Throwable {
+    when(contextMock.isMaxLatencyAchieved()).thenReturn(false);
+    try {
+      statement.evaluate();
+      fail("Assertion expected during validation");
+    } catch (Error e) {
+      assertThat(e.getMessage(), startsWith("Test max latency threshold not achieved"));
+    }
+  }
+
+  @Test
   public void whenEvaluationCompletes_andErrorValidationFails_thenAssertionShouldBeGenerated() throws Throwable {
     when(contextMock.isErrorThresholdAchieved()).thenReturn(false);
     try {
@@ -167,6 +200,9 @@ public class PerformanceEvaluationStatementTest extends BaseTest {
     when(contextMock.getConfiguredDuration()).thenReturn(100);
     when(contextMock.isErrorThresholdAchieved()).thenReturn(true);
     when(contextMock.isThroughputAchieved()).thenReturn(true);
+    when(contextMock.isMaxLatencyAchieved()).thenReturn(true);
+    when(contextMock.isMinLatencyAchieved()).thenReturn(true);
+    when(contextMock.isMeanLatencyAchieved()).thenReturn(true);
     when(contextMock.getPercentileResults()).thenReturn(emptyMap());
   }
 

--- a/junitperf-junit4/build.gradle
+++ b/junitperf-junit4/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.github.noconnor'
-version '1.16.0'
+version '1.16.1'
 
 dependencies {
     implementation project(':junitperf-core')

--- a/junitperf-junit5/build.gradle
+++ b/junitperf-junit5/build.gradle
@@ -1,6 +1,6 @@
 
 group 'com.github.noconnor'
-version '1.16.0'
+version '1.16.1'
 
 dependencies {
     implementation project(':junitperf-core')


### PR DESCRIPTION
Fixes #53 

## Proposed Changes

  - Update to verify min/max/mean latency thresholds are checked after test has completed
