### PR TITLE
Noconnor/allow runtime system property overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ More information on statistic calculations can be found [here](#statistics)
 | maxExecutionsPerSecond | Sets the maximum number of iteration per second (disabled by default)                                                             |       -1       |
 | rampUpPeriodMs         | Framework ramps up its executions per second smoothly over the duration of this period (disabled by default)                      |        0       |
 
+These configuration parameters can be overridden at runtime by specifying a VM args of the form: `-Djunitperf.<param>=X`
+
+i.e. To set a test duration of 10 mins at runtime, specify `-Djunitperf.durationMs=600_000`.
+This will override the `durationMs` set in the `@JUnitPerfTest` annotation.
+
 <br />
 
 `@JUnitPerfTestRequirement` has the following configuration parameters:
@@ -360,6 +365,10 @@ With this configuration a HTML report **AND** a CSV report will be generated
 
 By default, statistics are captured and calculated using the apache [Descriptive Statistics library](http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics).
 See [DescriptiveStatisticsCalculator](junitperf-core/src/main/java/com/github/noconnor/junitperf/statistics/providers/DescriptiveStatisticsCalculator.java) for more details.
+
+The default statistics calculator has an "infinite" size sampling window.
+As a result, long running tests may require a lot of memory to hold all test samples.
+The window size may be set to a fixed size as follows : `new DescriptiveStatisticsCalculator(1_000_000)` 
 
 To override the default statistics calculation class, a custom implementation of the `StatisticsCalculator` interface can 
 be passed to the `JUnitPerfRule` constructor:

--- a/README.md
+++ b/README.md
@@ -218,8 +218,10 @@ More information on statistic calculations can be found [here](#statistics)
 
 These configuration parameters can be overridden at runtime by specifying a VM args of the form: `-Djunitperf.<param>=X`
 
-i.e. To set a test duration of 10 mins at runtime, specify `-Djunitperf.durationMs=600_000`.
+i.e. To set a test duration of 10 mins at runtime, specify `-Djunitperf.durationMs=600000`.
 This will override the `durationMs` set in the `@JUnitPerfTest` annotation.
+
+**NOTE:** Do not use "_" when defining runtime integer or long override values, i.e. use `600000` and not `600_000`
 
 <br />
 

--- a/junitperf-core/pom.xml
+++ b/junitperf-core/pom.xml
@@ -14,38 +14,38 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
+            <version>${lombok.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>${commons.lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.3</version>
+            <version>${logback.classic.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.2</version>
+            <version>${commons.collection.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
-            <version>3.6.1</version>
+            <version>${commons.math3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jtwig</groupId>
             <artifactId>jtwig-core</artifactId>
-            <version>5.86.1.RELEASE</version>
+            <version>${jtwig.core.version}</version>
         </dependency>
     </dependencies>
 

--- a/junitperf-core/src/main/java/com/github/noconnor/junitperf/data/EvaluationContext.java
+++ b/junitperf-core/src/main/java/com/github/noconnor/junitperf/data/EvaluationContext.java
@@ -1,19 +1,5 @@
 package com.github.noconnor.junitperf.data;
 
-import com.github.noconnor.junitperf.JUnitPerfTest;
-import com.github.noconnor.junitperf.JUnitPerfTestRequirement;
-import com.github.noconnor.junitperf.datetime.DatetimeUtils;
-import com.github.noconnor.junitperf.statistics.StatisticsCalculator;
-import com.google.common.primitives.Floats;
-import com.google.common.primitives.Ints;
-
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-
-import java.util.Map;
-import java.util.stream.Stream;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Maps.newTreeMap;
@@ -23,7 +9,27 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.IntStream.range;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import com.github.noconnor.junitperf.JUnitPerfTest;
+import com.github.noconnor.junitperf.JUnitPerfTestRequirement;
+import com.github.noconnor.junitperf.datetime.DatetimeUtils;
+import com.github.noconnor.junitperf.statistics.StatisticsCalculator;
+import com.google.common.primitives.Floats;
+import com.google.common.primitives.Ints;
+import java.util.Map;
+import java.util.stream.Stream;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+@Slf4j
 public class EvaluationContext {
+
+  static final String JUNITPERF_THREADS = "junitperf.threads";
+  static final String JUNITPERF_WARM_UP_MS = "junitperf.warmUpMs";
+  static final String JUNITPERF_DURATION_MS = "junitperf.durationMs";
+  static final String JUNITPERF_RAMP_UP_PERIOD_MS = "junitperf.rampUpPeriodMs";
+  static final String JUNITPERF_MAX_EXECUTIONS_PER_SECOND = "junitperf.maxExecutionsPerSecond";
 
   @Getter
   private int configuredThreads;
@@ -112,23 +118,24 @@ public class EvaluationContext {
   }
 
   public void loadConfiguration(JUnitPerfTest testSettings) {
-    validateTestSettings(testSettings);
-    configuredThreads = testSettings.threads();
-    configuredDuration = testSettings.durationMs();
-    configuredWarmUp = testSettings.warmUpMs();
-    configuredRateLimit = testSettings.maxExecutionsPerSecond();
-    configuredRampUpPeriodMs = testSettings.rampUpPeriodMs();
+    checkNotNull(testSettings, "Test settings must not be null");
+    configuredThreads = checkForEnvOverride(JUNITPERF_THREADS, testSettings.threads());
+    configuredDuration = checkForEnvOverride(JUNITPERF_DURATION_MS, testSettings.durationMs());
+    configuredWarmUp = checkForEnvOverride(JUNITPERF_WARM_UP_MS, testSettings.warmUpMs());
+    configuredRateLimit = checkForEnvOverride(JUNITPERF_MAX_EXECUTIONS_PER_SECOND, testSettings.maxExecutionsPerSecond());
+    configuredRampUpPeriodMs = checkForEnvOverride(JUNITPERF_RAMP_UP_PERIOD_MS, testSettings.rampUpPeriodMs());
+    validateTestSettings();
   }
 
   public void loadRequirements(JUnitPerfTestRequirement requirements) {
     if (nonNull(requirements)) {
-      validateRequirements(requirements);
       requiredThroughput = requirements.executionsPerSec();
       requiredAllowedErrorsRate = requirements.allowedErrorPercentage();
       requiredPercentiles = parsePercentileLimits(requirements.percentiles());
       requiredMinLatency = requirements.minLatency();
       requiredMaxLatency = requirements.maxLatency();
       requiredMeanLatency = requirements.meanLatency();
+      validateRequirements();
     }
   }
 
@@ -181,21 +188,19 @@ public class EvaluationContext {
     return limits;
   }
 
-  private void validateTestSettings(JUnitPerfTest testSettings) {
-    checkNotNull(testSettings, "Test settings must not be null");
-    checkState(testSettings.durationMs() > 0, "DurationMs must be greater than 0ms");
-    checkState(testSettings.rampUpPeriodMs() >= 0, "RampUpPeriodMs must be >= 0ms");
-    checkState(testSettings.rampUpPeriodMs() < testSettings.durationMs(), "RampUpPeriodMs must be < DurationMs");
-    checkState(testSettings.warmUpMs() >= 0, "WarmUpMs must be >= 0ms");
-    checkState(testSettings.warmUpMs() < testSettings.durationMs(), "WarmUpMs must be < DurationMs");
-    checkState(testSettings.threads() > 0, "Threads must be > 0");
-    checkState(testSettings.maxExecutionsPerSecond() > 0 || testSettings.maxExecutionsPerSecond() == -1,
-      "MaxExecutionsPerSecond must be > 0 or -1 (to disable)");
+  private void validateTestSettings() {
+    checkState(configuredDuration > 0, "DurationMs must be greater than 0ms");
+    checkState(configuredRampUpPeriodMs >= 0, "RampUpPeriodMs must be >= 0ms");
+    checkState(configuredRampUpPeriodMs < configuredDuration, "RampUpPeriodMs must be < DurationMs");
+    checkState(configuredWarmUp >= 0, "WarmUpMs must be >= 0ms");
+    checkState(configuredWarmUp < configuredDuration, "WarmUpMs must be < DurationMs");
+    checkState(configuredThreads > 0, "Threads must be > 0");
+    checkState(configuredRateLimit > 0 || configuredRateLimit == -1,"MaxExecutionsPerSecond must be > 0 or -1 (to disable)");
   }
 
-  private void validateRequirements(JUnitPerfTestRequirement requirements) {
-    checkState(requirements.allowedErrorPercentage() >= 0, "AllowedErrorPercentage must be >= 0");
-    checkState(requirements.executionsPerSec() >= 0, "ExecutionsPerSec must be >= 0");
+  private void validateRequirements() {
+    checkState(requiredAllowedErrorsRate >= 0, "AllowedErrorPercentage must be >= 0");
+    checkState(requiredThroughput >= 0, "ExecutionsPerSec must be >= 0");
   }
 
   private void calculateAndCacheStatistics() {
@@ -208,6 +213,15 @@ public class EvaluationContext {
     errorPercentage = statistics.getErrorPercentage();
     errorCount = statistics.getErrorCount();
     evaluationCount = statistics.getEvaluationCount();
+  }
+
+  private int checkForEnvOverride(String name, int defaultValue){
+    Integer override = Integer.getInteger(name);
+    if (nonNull(override)) {
+      log.info("Using -D{} override: {}", name, override);
+      return override;
+    }
+    return defaultValue;
   }
 
 }

--- a/junitperf-core/src/main/java/com/github/noconnor/junitperf/data/EvaluationContext.java
+++ b/junitperf-core/src/main/java/com/github/noconnor/junitperf/data/EvaluationContext.java
@@ -15,7 +15,10 @@ import com.github.noconnor.junitperf.datetime.DatetimeUtils;
 import com.github.noconnor.junitperf.statistics.StatisticsCalculator;
 import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.Setter;
@@ -115,6 +118,10 @@ public class EvaluationContext {
 
   public float getLatencyPercentileMs(int percentile) {
     return percentiles[percentile];
+  }
+
+  public String getTestDurationFormatted() {
+    return DatetimeUtils.format(configuredDuration);
   }
 
   public void loadConfiguration(JUnitPerfTest testSettings) {

--- a/junitperf-core/src/main/java/com/github/noconnor/junitperf/datetime/DatetimeUtils.java
+++ b/junitperf-core/src/main/java/com/github/noconnor/junitperf/datetime/DatetimeUtils.java
@@ -21,4 +21,21 @@ public class DatetimeUtils {
     return LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
   }
 
+  public static String format(int durationMs) {
+    long seconds = durationMs / 1000;
+    long minutes = seconds / 60;
+    long hours = minutes / 60;
+    long days = hours / 24;
+    if (days > 0){
+      return days + "d:" + hours % 24 + "h:" + minutes % 60 + "m:" + seconds % 60 + "s";
+    } else if (hours > 0){
+      return hours % 24 + "h:" + minutes % 60 + "m:" + seconds % 60 + "s";
+    } else if (minutes > 0){
+      return minutes % 60 + "m:" + seconds % 60 + "s";
+    } if (seconds > 0){
+      return (seconds % 60) + "s";
+    } else {
+      return durationMs + "ms";
+    }
+  }
 }

--- a/junitperf-core/src/main/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGenerator.java
+++ b/junitperf-core/src/main/java/com/github/noconnor/junitperf/reporting/providers/ConsoleReportGenerator.java
@@ -42,7 +42,7 @@ public class ConsoleReportGenerator implements ReportGenerator {
     log.info("Warm up:      {} ms", context.getConfiguredWarmUp());
     log.info("Ramp up:      {} ms", context.getConfiguredRampUpPeriodMs());
     log.info("");
-    log.info("Execution time: {} ms", context.getConfiguredDuration());
+    log.info("Execution time: {}", context.getTestDurationFormatted());
     log.info("Throughput:     {}/s (Required: {}/s) - {}",
       context.getThroughputQps(),
       context.getRequiredThroughput(),

--- a/junitperf-core/src/main/resources/templates/report.twig
+++ b/junitperf-core/src/main/resources/templates/report.twig
@@ -134,7 +134,7 @@
                         </tr>
                         <tr>
                             <th align='right' valign='top'>Execution time:</th>
-                            <td align='right'>{{ number_format(context.configuredDuration, 0, ".", ",") }} ms</td>
+                            <td align='right'>{{ context.getTestDurationFormatted() }}</td>
                             <td align='right'></td>
                         </tr>
                         <tr>

--- a/junitperf-core/src/test/java/com/github/noconnor/junitperf/data/EvaluationContextTest.java
+++ b/junitperf-core/src/test/java/com/github/noconnor/junitperf/data/EvaluationContextTest.java
@@ -398,6 +398,16 @@ public class EvaluationContextTest extends BaseTest {
     assertTrue(context.isAsyncEvaluation());
   }
 
+  @Test
+  public void whenDurationIsValid_thenDurationShouldBeFormatted() {
+    when(perfTestAnnotation.durationMs()).thenReturn(100_000_000);
+    context.loadConfiguration(perfTestAnnotation);
+    assertEquals("1d:3h:46m:40s", context.getTestDurationFormatted());
+    when(perfTestAnnotation.durationMs()).thenReturn(300);
+    context.loadConfiguration(perfTestAnnotation);
+    assertEquals("300ms", context.getTestDurationFormatted());
+  }
+
   private void initialiseContext() {
     context.loadConfiguration(perfTestAnnotation);
     context.loadRequirements(perfTestRequirement);

--- a/junitperf-core/src/test/java/com/github/noconnor/junitperf/data/EvaluationContextTest.java
+++ b/junitperf-core/src/test/java/com/github/noconnor/junitperf/data/EvaluationContextTest.java
@@ -1,25 +1,30 @@
 package com.github.noconnor.junitperf.data;
 
-import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
+import static com.github.noconnor.junitperf.data.EvaluationContext.JUNITPERF_DURATION_MS;
+import static com.github.noconnor.junitperf.data.EvaluationContext.JUNITPERF_MAX_EXECUTIONS_PER_SECOND;
+import static com.github.noconnor.junitperf.data.EvaluationContext.JUNITPERF_RAMP_UP_PERIOD_MS;
+import static com.github.noconnor.junitperf.data.EvaluationContext.JUNITPERF_THREADS;
+import static com.github.noconnor.junitperf.data.EvaluationContext.JUNITPERF_WARM_UP_MS;
+import static java.lang.System.nanoTime;
+import static java.util.Collections.emptyMap;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
 import com.github.noconnor.junitperf.BaseTest;
 import com.github.noconnor.junitperf.JUnitPerfTest;
 import com.github.noconnor.junitperf.JUnitPerfTestRequirement;
 import com.github.noconnor.junitperf.datetime.DatetimeUtils;
 import com.github.noconnor.junitperf.statistics.StatisticsCalculator;
 import com.google.common.collect.ImmutableMap;
-
-import static java.lang.System.nanoTime;
-import static java.util.Collections.emptyMap;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.when;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 public class EvaluationContextTest extends BaseTest {
 
@@ -46,14 +51,38 @@ public class EvaluationContextTest extends BaseTest {
     context = new EvaluationContext(TEST_NAME, nanoTime());
   }
 
+  @After
+  public void tearDown(){
+    System.clearProperty(JUNITPERF_THREADS);
+    System.clearProperty(JUNITPERF_DURATION_MS);
+    System.clearProperty(JUNITPERF_WARM_UP_MS);
+    System.clearProperty(JUNITPERF_MAX_EXECUTIONS_PER_SECOND);
+    System.clearProperty(JUNITPERF_RAMP_UP_PERIOD_MS);
+  }
+
   @Test
   public void whenLoadingJUnitPerfTestSettings_thenAppropriateContextSettingsShouldBeUpdated() {
     context.loadConfiguration(perfTestAnnotation);
-    assertThat(context.getConfiguredDuration(), is(perfTestAnnotation.durationMs()));
-    assertThat(context.getConfiguredRateLimit(), is(perfTestAnnotation.maxExecutionsPerSecond()));
-    assertThat(context.getConfiguredThreads(), is(perfTestAnnotation.threads()));
-    assertThat(context.getConfiguredWarmUp(), is(perfTestAnnotation.warmUpMs()));
-    assertThat(context.getConfiguredRampUpPeriodMs(), is(perfTestAnnotation.rampUpPeriodMs()));
+    assertEquals(perfTestAnnotation.durationMs(), context.getConfiguredDuration());
+    assertEquals(perfTestAnnotation.maxExecutionsPerSecond(), context.getConfiguredRateLimit());
+    assertEquals(perfTestAnnotation.threads(), context.getConfiguredThreads());
+    assertEquals(perfTestAnnotation.warmUpMs(), context.getConfiguredWarmUp());
+    assertEquals(perfTestAnnotation.rampUpPeriodMs(), context.getConfiguredRampUpPeriodMs());
+  }
+
+  @Test
+  public void whenLoadingJUnitPerfTestSettings_andEnvironmentHasOverrides_thenAppropriateContextSettingsShouldBeUpdated() {
+    System.setProperty(JUNITPERF_THREADS, "45");
+    System.setProperty(JUNITPERF_DURATION_MS, "60000");
+    System.setProperty(JUNITPERF_WARM_UP_MS, "2000");
+    System.setProperty(JUNITPERF_MAX_EXECUTIONS_PER_SECOND, "55");
+    System.setProperty(JUNITPERF_RAMP_UP_PERIOD_MS, "1000");
+    context.loadConfiguration(perfTestAnnotation);
+    assertEquals(60000, context.getConfiguredDuration());
+    assertEquals(55, context.getConfiguredRateLimit());
+    assertEquals(45, context.getConfiguredThreads());
+    assertEquals(2000, context.getConfiguredWarmUp());
+    assertEquals(1000, context.getConfiguredRampUpPeriodMs());
   }
 
   @Test
@@ -65,8 +94,22 @@ public class EvaluationContextTest extends BaseTest {
   }
 
   @Test
+  public void whenLoadingJUnitPerfTestSettings_andEnvOverridesAreSet_thenDurationMsShouldBeSensible() {
+    System.setProperty(JUNITPERF_DURATION_MS, "0");
+    expectValidationError("DurationMs must be greater than 0ms");
+    System.setProperty(JUNITPERF_DURATION_MS, "-98");
+    expectValidationError("DurationMs must be greater than 0ms");
+  }
+
+  @Test
   public void whenLoadingJUnitPerfTestSettings_thenRampUpMsShouldBeGreaterThanZero() {
     when(perfTestAnnotation.rampUpPeriodMs()).thenReturn(-9);
+    expectValidationError("RampUpPeriodMs must be >= 0ms");
+  }
+
+  @Test
+  public void whenLoadingJUnitPerfTestSettings_andEnvOverridesAreSet_thenRampUpMsShouldBeGreaterThanZero() {
+    System.setProperty(JUNITPERF_RAMP_UP_PERIOD_MS, "-8");
     expectValidationError("RampUpPeriodMs must be >= 0ms");
   }
 
@@ -74,6 +117,13 @@ public class EvaluationContextTest extends BaseTest {
   public void whenLoadingJUnitPerfTestSettings_thenRampUpMsShouldBeLessThanTestDuration() {
     when(perfTestAnnotation.rampUpPeriodMs()).thenReturn(60);
     when(perfTestAnnotation.durationMs()).thenReturn(50);
+    expectValidationError("RampUpPeriodMs must be < DurationMs");
+  }
+
+  @Test
+  public void whenLoadingJUnitPerfTestSettings_andEnvOverridesAreSet_thenRampUpMsShouldBeLessThanTestDuration() {
+    System.setProperty(JUNITPERF_RAMP_UP_PERIOD_MS, "67");
+    System.setProperty(JUNITPERF_DURATION_MS, "55");
     expectValidationError("RampUpPeriodMs must be < DurationMs");
   }
 
@@ -87,10 +137,27 @@ public class EvaluationContextTest extends BaseTest {
   }
 
   @Test
+  public void whenLoadingJUnitPerfTestSettings_andEnvOverridesAreSet_thenWarmUpMsShouldBeSensible() {
+    System.setProperty(JUNITPERF_WARM_UP_MS, "-88");
+    expectValidationError("WarmUpMs must be >= 0ms");
+    System.setProperty(JUNITPERF_DURATION_MS, "38");
+    System.setProperty(JUNITPERF_WARM_UP_MS, "44");
+    expectValidationError("WarmUpMs must be < DurationMs");
+  }
+
+  @Test
   public void whenLoadingJUnitPerfTestSettings_thenThreadsShouldBeSensible() {
     when(perfTestAnnotation.threads()).thenReturn(-9);
     expectValidationError("Threads must be > 0");
     when(perfTestAnnotation.threads()).thenReturn(0);
+    expectValidationError("Threads must be > 0");
+  }
+
+  @Test
+  public void whenLoadingJUnitPerfTestSettings_andEnvOverridesAreSet_thenThreadsShouldBeSensible() {
+    System.setProperty(JUNITPERF_THREADS, "-88");
+    expectValidationError("Threads must be > 0");
+    System.setProperty(JUNITPERF_THREADS, "0");
     expectValidationError("Threads must be > 0");
   }
 
@@ -105,6 +172,17 @@ public class EvaluationContextTest extends BaseTest {
     context.loadConfiguration(perfTestAnnotation);
   }
 
+  @Test
+  public void whenLoadingJUnitPerfTestSettings_andEnvOverridesAreSet_thenMaxExecutionsPerSecondShouldBeSensible() {
+    System.setProperty(JUNITPERF_MAX_EXECUTIONS_PER_SECOND, "-8");
+    expectValidationError("MaxExecutionsPerSecond must be > 0 or -1 (to disable)");
+    System.setProperty(JUNITPERF_MAX_EXECUTIONS_PER_SECOND, "0");
+    expectValidationError("MaxExecutionsPerSecond must be > 0 or -1 (to disable)");
+    // ALLOWED value
+    System.setProperty(JUNITPERF_MAX_EXECUTIONS_PER_SECOND, "-1");
+    context.loadConfiguration(perfTestAnnotation);
+  }
+
   @Test(expected = NullPointerException.class)
   public void whenLoadingJUnitPerfTestSettings_andSettingsAreNull_thenExceptionShouldBeThrown() {
     context.loadConfiguration(null);
@@ -113,9 +191,9 @@ public class EvaluationContextTest extends BaseTest {
   @Test
   public void whenLoadingJUnitPerfTestRequirements_thenAppropriateContextSettingsShouldBeUpdated() {
     context.loadRequirements(perfTestRequirement);
-    assertThat(context.getRequiredAllowedErrorsRate(), is(perfTestRequirement.allowedErrorPercentage()));
-    assertThat(context.getRequiredThroughput(), is(perfTestRequirement.executionsPerSec()));
-    assertThat(context.getRequiredPercentiles(), is(ImmutableMap.of(90, 0.5F, 95, 9F)));
+    assertEquals(perfTestRequirement.allowedErrorPercentage(), context.getRequiredAllowedErrorsRate(),0);
+    assertEquals(perfTestRequirement.executionsPerSec(), context.getRequiredThroughput());
+    assertEquals(ImmutableMap.of(90, 0.5F, 95, 9F), context.getRequiredPercentiles());
   }
 
   @Test
@@ -139,8 +217,8 @@ public class EvaluationContextTest extends BaseTest {
   public void whenRunningEvaluation_thenThroughputRequirementsShouldBeChecked() {
     initialiseContext();
     context.runValidation();
-    assertThat(context.isThroughputAchieved(), is(true));
-    assertThat(context.isSuccessful(), is(true));
+    assertTrue(context.isThroughputAchieved());
+    assertTrue(context.isSuccessful());
   }
 
   @Test
@@ -148,8 +226,8 @@ public class EvaluationContextTest extends BaseTest {
     when(statisticsMock.getEvaluationCount()).thenReturn(10L);
     initialiseContext();
     context.runValidation();
-    assertThat(context.isThroughputAchieved(), is(false));
-    assertThat(context.isSuccessful(), is(false));
+    assertFalse(context.isThroughputAchieved());
+    assertFalse(context.isSuccessful());
   }
 
   @Test
@@ -159,15 +237,15 @@ public class EvaluationContextTest extends BaseTest {
     when(perfTestAnnotation.warmUpMs()).thenReturn(5);
     initialiseContext();
     context.runValidation();
-    assertThat(context.getThroughputQps(), is(10526L));
+    assertEquals(10526L, context.getThroughputQps());
   }
 
   @Test
   public void whenRunningEvaluation_thenAllowedErrorsRequirementsShouldBeChecked() {
     initialiseContext();
     context.runValidation();
-    assertThat(context.isErrorThresholdAchieved(), is(true));
-    assertThat(context.isSuccessful(), is(true));
+    assertTrue(context.isErrorThresholdAchieved());
+    assertTrue(context.isSuccessful());
   }
 
   @Test
@@ -175,8 +253,8 @@ public class EvaluationContextTest extends BaseTest {
     when(statisticsMock.getErrorPercentage()).thenReturn(60F);
     initialiseContext();
     context.runValidation();
-    assertThat(context.isErrorThresholdAchieved(), is(false));
-    assertThat(context.isSuccessful(), is(false));
+    assertFalse(context.isErrorThresholdAchieved());
+    assertFalse(context.isSuccessful());
   }
 
   @Test
@@ -184,7 +262,7 @@ public class EvaluationContextTest extends BaseTest {
     Map<Integer, Boolean> validationResults = ImmutableMap.of(90, true, 95, true);
     initialiseContext();
     context.runValidation();
-    assertThat(context.getPercentileResults(), is(validationResults));
+    assertEquals(validationResults, context.getPercentileResults());
   }
 
   @Test
@@ -193,15 +271,15 @@ public class EvaluationContextTest extends BaseTest {
     Map<Integer, Boolean> validationResults = ImmutableMap.of(90, false, 95, true);
     initialiseContext();
     context.runValidation();
-    assertThat(context.getPercentileResults(), is(validationResults));
-    assertThat(context.isSuccessful(), is(false));
+    assertEquals(validationResults, context.getPercentileResults());
+    assertFalse(context.isSuccessful());
   }
 
   @Test
   public void whenRunningEvaluation_andAllThresholdsAreMet_thenIsSuccessfulShouldBeTrue() {
     initialiseContext();
     context.runValidation();
-    assertThat(context.isSuccessful(), is(true));
+    assertTrue(context.isSuccessful());
   }
 
   @Test
@@ -209,10 +287,10 @@ public class EvaluationContextTest extends BaseTest {
     context.loadConfiguration(perfTestAnnotation);
     context.setStatistics(statisticsMock);
     context.runValidation();
-    assertThat(context.isSuccessful(), is(true));
-    assertThat(context.isErrorThresholdAchieved(), is(true));
-    assertThat(context.isThroughputAchieved(), is(true));
-    assertThat(context.getPercentileResults(), is(anEmptyMap()));
+    assertTrue(context.isSuccessful());
+    assertTrue(context.isErrorThresholdAchieved());
+    assertTrue(context.isThroughputAchieved());
+    assertEquals(emptyMap(), context.getPercentileResults());
   }
 
   @Test
@@ -248,15 +326,15 @@ public class EvaluationContextTest extends BaseTest {
     context.runValidation();
     long expected = (long)(statisticsMock.getEvaluationCount() / (float)(perfTestAnnotation.durationMs() - perfTestAnnotation
       .warmUpMs())) * 1000;
-    assertThat(context.getThroughputQps(), is(expected));
+    assertEquals(expected, context.getThroughputQps());
   }
 
   @Test
   public void whenRunningEvaluation_thenMinLatencyRequirementsShouldBeChecked() {
     initialiseContext();
     context.runValidation();
-    assertThat(context.isMinLatencyAchieved(), is(true));
-    assertThat(context.isSuccessful(), is(true));
+    assertTrue(context.isMinLatencyAchieved());
+    assertTrue(context.isSuccessful());
   }
 
   @Test
@@ -264,16 +342,16 @@ public class EvaluationContextTest extends BaseTest {
     when(statisticsMock.getMinLatency(MILLISECONDS)).thenReturn(60.9F);
     initialiseContext();
     context.runValidation();
-    assertThat(context.isMinLatencyAchieved(), is(false));
-    assertThat(context.isSuccessful(), is(false));
+    assertFalse(context.isMinLatencyAchieved());
+    assertFalse(context.isSuccessful());
   }
 
   @Test
   public void whenRunningEvaluation_thenMaxLatencyRequirementsShouldBeChecked() {
     initialiseContext();
     context.runValidation();
-    assertThat(context.isMaxLatencyAchieved(), is(true));
-    assertThat(context.isSuccessful(), is(true));
+    assertTrue(context.isMaxLatencyAchieved());
+    assertTrue(context.isSuccessful());
   }
 
   @Test
@@ -281,16 +359,16 @@ public class EvaluationContextTest extends BaseTest {
     when(statisticsMock.getMaxLatency(MILLISECONDS)).thenReturn(190.9F);
     initialiseContext();
     context.runValidation();
-    assertThat(context.isMaxLatencyAchieved(), is(false));
-    assertThat(context.isSuccessful(), is(false));
+    assertFalse(context.isMaxLatencyAchieved());
+    assertFalse(context.isSuccessful());
   }
 
   @Test
   public void whenRunningEvaluation_thenMeanLatencyRequirementsShouldBeChecked() {
     initialiseContext();
     context.runValidation();
-    assertThat(context.isMeanLatencyAchieved(), is(true));
-    assertThat(context.isSuccessful(), is(true));
+    assertTrue(context.isMeanLatencyAchieved());
+    assertTrue(context.isSuccessful());
   }
 
   @Test
@@ -298,26 +376,26 @@ public class EvaluationContextTest extends BaseTest {
     when(statisticsMock.getMeanLatency(MILLISECONDS)).thenReturn(10.9F);
     initialiseContext();
     context.runValidation();
-    assertThat(context.isMeanLatencyAchieved(), is(false));
-    assertThat(context.isSuccessful(), is(false));
+    assertFalse(context.isMeanLatencyAchieved());
+    assertFalse(context.isSuccessful());
   }
 
   @Test
   public void whenSupplyingANanosecondStartTime_thenTheStartTimeShouldBeSet() {
     long now = nanoTime();
     context = new EvaluationContext(TEST_NAME, now);
-    assertThat(context.getStartTimeNs(), is(now));
+    assertEquals(now, context.getStartTimeNs());
   }
 
   @Test
   public void whenCreatingDefaultContext_thenIsAsyncShouldBeFalse() {
-    assertThat(context.isAsyncEvaluation(), is(false));
+    assertFalse(context.isAsyncEvaluation());
   }
 
   @Test
   public void whenSpecifyingAsyncFlag_thenIsAsyncShouldBeTrue() {
     context = new EvaluationContext(TEST_NAME, nanoTime(), true);
-    assertThat(context.isAsyncEvaluation(), is(true));
+    assertTrue(context.isAsyncEvaluation());
   }
 
   private void initialiseContext() {
@@ -356,7 +434,7 @@ public class EvaluationContextTest extends BaseTest {
 
   private void loadPercentilesAndAssertParsedCorrectly(String percentiles, Map<Integer, Float> expected) {
     loadPercentiles(percentiles);
-    assertThat(context.getRequiredPercentiles(), is(expected));
+    assertEquals(expected, context.getRequiredPercentiles());
   }
 
   private void loadPercentiles(String percentiles) {
@@ -369,7 +447,7 @@ public class EvaluationContextTest extends BaseTest {
       context.loadConfiguration(perfTestAnnotation);
       fail("Expected validation Exception");
     } catch (IllegalStateException e) {
-      assertThat(e.getMessage(), startsWith(expectedMessage));
+      assertTrue(e.getMessage().startsWith(expectedMessage));
     }
   }
 
@@ -378,7 +456,7 @@ public class EvaluationContextTest extends BaseTest {
       context.loadRequirements(perfTestRequirement);
       fail("Expected requirements validation Exception");
     } catch (Exception e) {
-      assertThat(e.getMessage(), startsWith(expectedMessage));
+      assertTrue(e.getMessage().startsWith(expectedMessage));
     }
   }
 

--- a/junitperf-core/src/test/java/com/github/noconnor/junitperf/datetime/DatetimeUtilsTest.java
+++ b/junitperf-core/src/test/java/com/github/noconnor/junitperf/datetime/DatetimeUtilsTest.java
@@ -1,17 +1,16 @@
 package com.github.noconnor.junitperf.datetime;
 
-import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 public class DatetimeUtilsTest {
 
   @Test
   public void whenTimeHasBeenOverridden_thenTheOverriddenTimeShouldBeReturned() {
     DatetimeUtils.setOverride("TEST");
-    assertThat(DatetimeUtils.now(), is("TEST"));
+    assertEquals("TEST", DatetimeUtils.now());
   }
 
   @Test
@@ -19,6 +18,15 @@ public class DatetimeUtilsTest {
     DatetimeUtils.setOverride(null);
     String expectedPattern = "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}";
     assertTrue(DatetimeUtils.now().matches(expectedPattern));
+  }
+
+  @Test
+  public void whenDurationIsValid_thenDurationShouldBeFormatted() {
+    assertEquals("1d:3h:46m:40s", DatetimeUtils.format(100_000_000));
+    assertEquals("2h:46m:40s", DatetimeUtils.format(10_000_000));
+    assertEquals("16m:40s", DatetimeUtils.format(1_000_000));
+    assertEquals("59s", DatetimeUtils.format(59_000));
+    assertEquals("300ms", DatetimeUtils.format(300));
   }
 
 }

--- a/junitperf-core/src/test/java/com/github/noconnor/junitperf/reporting/providers/HtmlReportGeneratorTest.java
+++ b/junitperf-core/src/test/java/com/github/noconnor/junitperf/reporting/providers/HtmlReportGeneratorTest.java
@@ -9,6 +9,7 @@ import com.github.noconnor.junitperf.reporting.BaseReportGeneratorTest;
 
 import static java.lang.System.getProperty;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class HtmlReportGeneratorTest extends BaseReportGeneratorTest {
@@ -39,28 +40,28 @@ public class HtmlReportGeneratorTest extends BaseReportGeneratorTest {
   public void whenGeneratingAReport_andAllTestsFailed_thenAppropriateReportShouldBeGenerated() throws IOException {
     reportGenerator.generateReport(generateAllFailureOrderedContexts());
     File expectedContents = getResourceFile("html/example_all_failed_report.html");
-    assertThat(readFileContents(reportFile), is(readFileContents(expectedContents)));
+    assertEquals(readFileContents(expectedContents), readFileContents(reportFile));
   }
 
   @Test
   public void whenGeneratingAReport_andAllTestsPass_thenAppropriateReportShouldBeGenerated() throws IOException {
     reportGenerator.generateReport(generateAllPassedOrderedContexts());
     File expectedContents = getResourceFile("html/example_all_passed_report.html");
-    assertThat(readFileContents(reportFile), is(readFileContents(expectedContents)));
+    assertEquals(readFileContents(expectedContents), readFileContents(reportFile));
   }
 
   @Test
   public void whenGeneratingAReport_andTestsContainsAMixOfPassAndFailures_thenAppropriateReportShouldBeGenerated() throws IOException {
     reportGenerator.generateReport(generateMixedOrderedContexts());
     File expectedContents = getResourceFile("html/example_mixed_report.html");
-    assertThat(readFileContents(reportFile), is(readFileContents(expectedContents)));
+    assertEquals(readFileContents(expectedContents), readFileContents(reportFile));
   }
 
   @Test
   public void whenGeneratingAReport_andTestsContainsSomeFailures_thenAppropriateReportShouldBeGenerated() throws IOException {
     reportGenerator.generateReport(generateSomeFailuresContext());
     File expectedContents = getResourceFile("html/example_some_failures_report.html");
-    assertThat(readFileContents(reportFile), is(readFileContents(expectedContents)));
+    assertEquals(readFileContents(expectedContents), readFileContents(reportFile));
   }
 
   @Test
@@ -71,7 +72,7 @@ public class HtmlReportGeneratorTest extends BaseReportGeneratorTest {
   @Test
   public void whenCallingGetReportPath_andDefaultPathHasBeenSpecified_thenCorrectPathShouldBeReturned() {
     reportGenerator = new HtmlReportGenerator();
-    assertThat(reportGenerator.getReportPath(), is(getProperty("user.dir") + "/build/reports/junitperf_report.html"));
+    assertEquals(getProperty("user.dir") + "/build/reports/junitperf_report.html", reportGenerator.getReportPath());
   }
 
 }

--- a/junitperf-core/src/test/resources/html/example_all_failed_report.html
+++ b/junitperf-core/src/test/resources/html/example_all_failed_report.html
@@ -534,7 +534,7 @@
                         </tr>
                         <tr>
                             <th align='right' valign='top'>Execution time:</th>
-                            <td align='right'>10,000 ms</td>
+                            <td align='right'>10s</td>
                             <td align='right'></td>
                         </tr>
                         <tr>
@@ -1095,7 +1095,7 @@
                         </tr>
                         <tr>
                             <th align='right' valign='top'>Execution time:</th>
-                            <td align='right'>10,000 ms</td>
+                            <td align='right'>10s</td>
                             <td align='right'></td>
                         </tr>
                         <tr>

--- a/junitperf-core/src/test/resources/html/example_all_passed_report.html
+++ b/junitperf-core/src/test/resources/html/example_all_passed_report.html
@@ -534,7 +534,7 @@
                         </tr>
                         <tr>
                             <th align='right' valign='top'>Execution time:</th>
-                            <td align='right'>10,000 ms</td>
+                            <td align='right'>10s</td>
                             <td align='right'></td>
                         </tr>
                         <tr>
@@ -1095,7 +1095,7 @@
                         </tr>
                         <tr>
                             <th align='right' valign='top'>Execution time:</th>
-                            <td align='right'>10,000 ms</td>
+                            <td align='right'>10s</td>
                             <td align='right'></td>
                         </tr>
                         <tr>

--- a/junitperf-core/src/test/resources/html/example_mixed_report.html
+++ b/junitperf-core/src/test/resources/html/example_mixed_report.html
@@ -534,7 +534,7 @@
                         </tr>
                         <tr>
                             <th align='right' valign='top'>Execution time:</th>
-                            <td align='right'>10,000 ms</td>
+                            <td align='right'>10s</td>
                             <td align='right'></td>
                         </tr>
                         <tr>
@@ -1095,7 +1095,7 @@
                         </tr>
                         <tr>
                             <th align='right' valign='top'>Execution time:</th>
-                            <td align='right'>10,000 ms</td>
+                            <td align='right'>10s</td>
                             <td align='right'></td>
                         </tr>
                         <tr>

--- a/junitperf-core/src/test/resources/html/example_some_failures_report.html
+++ b/junitperf-core/src/test/resources/html/example_some_failures_report.html
@@ -528,7 +528,7 @@
                         </tr>
                         <tr>
                             <th align='right' valign='top'>Execution time:</th>
-                            <td align='right'>10,000 ms</td>
+                            <td align='right'>10s</td>
                             <td align='right'></td>
                         </tr>
                         <tr>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,15 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <junit.version>4.13.2</junit.version>
-        <mockito.version>2.11.0</mockito.version>
+        <mockito.version>3.8.0</mockito.version>
         <hamcrest.version>2.0.0.0</hamcrest.version>
+        <lombok.version>1.18.18</lombok.version>
+        <commons.lang3.version>3.11</commons.lang3.version>
+        <logback.classic.version>1.2.3</logback.classic.version>
+        <guava.version>30.1-jre</guava.version>
+        <commons.collection.version>3.2.2</commons.collection.version>
+        <commons.math3.version>3.6.1</commons.math3.version>
+        <jtwig.core.version>5.86.1.RELEASE</jtwig.core.version>
         <jacoco-plugin-version>0.8.5</jacoco-plugin-version>
     </properties>
 


### PR DESCRIPTION
Fixes #Adding runtime override functionality

## Proposed Changes

  - Allow uses to override `@JUnitPerfTest` parameters at runtime using -D flags
  - Updating multiple dependencies
  - Fix for test duration formatting 