### PR TITLE
Fixing count resetting

### DIFF
--- a/junitperf-core/src/main/java/com/github/noconnor/junitperf/statistics/providers/DescriptiveStatisticsCalculator.java
+++ b/junitperf-core/src/main/java/com/github/noconnor/junitperf/statistics/providers/DescriptiveStatisticsCalculator.java
@@ -85,5 +85,7 @@ public class DescriptiveStatisticsCalculator implements StatisticsCalculator {
   @Override
   public void reset() {
     statistics.clear();
+    evaluationCount.set(0);
+    errorCount.set(0);
   }
 }

--- a/junitperf-core/src/test/java/com/github/noconnor/junitperf/statistics/providers/DescriptiveStatisticsCalculatorTest.java
+++ b/junitperf-core/src/test/java/com/github/noconnor/junitperf/statistics/providers/DescriptiveStatisticsCalculatorTest.java
@@ -9,6 +9,7 @@ import org.mockito.Spy;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 
@@ -142,7 +143,13 @@ public class DescriptiveStatisticsCalculatorTest extends BaseTest {
 
   @Test
   public void whenResettingStatsCollector_thenStatsShouldBeCleared() {
+    evaluator.incrementErrorCount();
+    evaluator.incrementEvaluationCount();
+    assertEquals(1, evaluator.getErrorCount());
+    assertEquals(1, evaluator.getEvaluationCount());
     evaluator.reset();
     verify(statsMock).clear();
+    assertEquals(0, evaluator.getErrorCount());
+    assertEquals(0, evaluator.getEvaluationCount());
   }
 }


### PR DESCRIPTION
Fixes #63 

## Proposed Changes

  - Missed impact: Error and eval counts should be reset when test statement is re-run
