### PR TITLE
Noconnor/bug fix for thread termination

### DIFF
--- a/junit4-examples/pom.xml
+++ b/junit4-examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.20.0-SNAPSHOT</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junit4-examples</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.noconnor</groupId>
             <artifactId>junitperf</artifactId>
-            <version>1.20.0-SNAPSHOT</version>
+            <version>1.20.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/junit4-examples/pom.xml
+++ b/junit4-examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.21.0-SNAPSHOT</version>
+        <version>1.21.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junit4-examples</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.noconnor</groupId>
             <artifactId>junitperf</artifactId>
-            <version>1.21.0-SNAPSHOT</version>
+            <version>1.21.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/junit4-examples/pom.xml
+++ b/junit4-examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.21.0</version>
+        <version>1.22.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junit4-examples</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.noconnor</groupId>
             <artifactId>junitperf</artifactId>
-            <version>1.21.0</version>
+            <version>1.22.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/junit4-examples/pom.xml
+++ b/junit4-examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junit4-examples</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.noconnor</groupId>
             <artifactId>junitperf</artifactId>
-            <version>1.20.0</version>
+            <version>1.21.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/junitperf-core/pom.xml
+++ b/junitperf-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junitperf-core</artifactId>

--- a/junitperf-core/pom.xml
+++ b/junitperf-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.21.0-SNAPSHOT</version>
+        <version>1.21.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junitperf-core</artifactId>

--- a/junitperf-core/pom.xml
+++ b/junitperf-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.20.0-SNAPSHOT</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junitperf-core</artifactId>

--- a/junitperf-core/pom.xml
+++ b/junitperf-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.21.0</version>
+        <version>1.22.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junitperf-core</artifactId>

--- a/junitperf-core/src/test/java/com/github/noconnor/junitperf/statements/EvaluationTaskTest.java
+++ b/junitperf-core/src/test/java/com/github/noconnor/junitperf/statements/EvaluationTaskTest.java
@@ -124,6 +124,7 @@ public class EvaluationTaskTest extends BaseTest {
     mockTerminateAfter(9990);
     task = new EvaluationTask(statementMock, null, terminatorMock, statsMock, 0);
     task.run();
+    // termination flag will still finish executing current loop
     verify(statsMock, times(9991)).incrementEvaluationCount();
     verify(statsMock, times(9991)).addLatencyMeasurement(anyLong());
     verify(statsMock, never()).incrementErrorCount();

--- a/junitperf-core/src/test/java/com/github/noconnor/junitperf/statements/EvaluationTaskTest.java
+++ b/junitperf-core/src/test/java/com/github/noconnor/junitperf/statements/EvaluationTaskTest.java
@@ -1,5 +1,6 @@
 package com.github.noconnor.junitperf.statements;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.junit.Before;
@@ -109,11 +110,22 @@ public class EvaluationTaskTest extends BaseTest {
   @Test
   public void whenAnInterruptExceptionIsThrown_thenNoErrorsMetricsShouldBeCaptured() throws Throwable {
     setExecutionCount(10000);
-    mockInterruptEvaluationFailures(5);
+    mockInterruptAfter(9995);
     task = new EvaluationTask(statementMock, null, terminatorMock, statsMock, 0);
     task.run();
     verify(statsMock, times(9995)).incrementEvaluationCount();
     verify(statsMock, times(9995)).addLatencyMeasurement(anyLong());
+    verify(statsMock, never()).incrementErrorCount();
+  }
+
+  @Test
+  public void whenTerminationFlagIsSet_thenNoMoreExecutionsShouldBeEvaluated() throws Throwable {
+    setExecutionCount(10000);
+    mockTerminateAfter(9990);
+    task = new EvaluationTask(statementMock, null, terminatorMock, statsMock, 0);
+    task.run();
+    verify(statsMock, times(9991)).incrementEvaluationCount();
+    verify(statsMock, times(9991)).addLatencyMeasurement(anyLong());
     verify(statsMock, never()).incrementErrorCount();
   }
 
@@ -174,15 +186,24 @@ public class EvaluationTaskTest extends BaseTest {
 
   }
 
-  private void mockInterruptEvaluationFailures(int desiredFailureCount) throws Throwable {
+  private void mockInterruptAfter(int desiredSuccessfulInvocations) throws Throwable {
     AtomicInteger executions = new AtomicInteger();
     doAnswer(invocation -> {
-      if (executions.getAndIncrement() < desiredFailureCount) {
+      if (executions.getAndIncrement() >= desiredSuccessfulInvocations) {
         throw new InterruptedException("mock exception");
       }
       return null;
     }).when(statementMock).evaluate();
+  }
 
+  private void mockTerminateAfter(int desiredSuccessfulInvocations) throws Throwable {
+    AtomicInteger executions = new AtomicInteger();
+    doAnswer(invocation -> {
+      if (executions.getAndIncrement() >= desiredSuccessfulInvocations) {
+        when(terminatorMock.get()).thenReturn(true);
+      }
+      return null;
+    }).when(statementMock).evaluate();
   }
 
   private void initialiseRateLimiterMock() {

--- a/junitperf-junit4/pom.xml
+++ b/junitperf-junit4/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.21.0</version>
+        <version>1.22.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junitperf</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.noconnor</groupId>
             <artifactId>junitperf-core</artifactId>
-            <version>1.21.0</version>
+            <version>1.22.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/junitperf-junit4/pom.xml
+++ b/junitperf-junit4/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.20.0-SNAPSHOT</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junitperf</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.noconnor</groupId>
             <artifactId>junitperf-core</artifactId>
-            <version>1.20.0-SNAPSHOT</version>
+            <version>1.20.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/junitperf-junit4/pom.xml
+++ b/junitperf-junit4/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junitperf</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.noconnor</groupId>
             <artifactId>junitperf-core</artifactId>
-            <version>1.20.0</version>
+            <version>1.21.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/junitperf-junit4/pom.xml
+++ b/junitperf-junit4/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.21.0-SNAPSHOT</version>
+        <version>1.21.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junitperf</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.noconnor</groupId>
             <artifactId>junitperf-core</artifactId>
-            <version>1.21.0-SNAPSHOT</version>
+            <version>1.21.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/junitperf-junit5/pom.xml
+++ b/junitperf-junit5/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.20.0</version>
+        <version>1.21.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junitperf-junit5</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.noconnor</groupId>
             <artifactId>junitperf-core</artifactId>
-            <version>1.20.0</version>
+            <version>1.21.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/junitperf-junit5/pom.xml
+++ b/junitperf-junit5/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.21.0-SNAPSHOT</version>
+        <version>1.21.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junitperf-junit5</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.noconnor</groupId>
             <artifactId>junitperf-core</artifactId>
-            <version>1.21.0-SNAPSHOT</version>
+            <version>1.21.0</version>
         </dependency>
     </dependencies>
 

--- a/junitperf-junit5/pom.xml
+++ b/junitperf-junit5/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.20.0-SNAPSHOT</version>
+        <version>1.20.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junitperf-junit5</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.noconnor</groupId>
             <artifactId>junitperf-core</artifactId>
-            <version>1.20.0-SNAPSHOT</version>
+            <version>1.20.0</version>
         </dependency>
     </dependencies>
 

--- a/junitperf-junit5/pom.xml
+++ b/junitperf-junit5/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>junitperf-parent</artifactId>
         <groupId>com.github.noconnor</groupId>
-        <version>1.21.0</version>
+        <version>1.22.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>junitperf-junit5</artifactId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.github.noconnor</groupId>
             <artifactId>junitperf-core</artifactId>
-            <version>1.21.0</version>
+            <version>1.22.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.noconnor</groupId>
     <artifactId>junitperf-parent</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>junitperf</name>
@@ -208,7 +208,7 @@
         <connection>scm:git:ssh://git@github.com:noconnor/JUnitPerf.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:noconnor/JUnitPerf.git</developerConnection>
         <url>git@github.com:noconnor/JUnitPerf.git</url>
-        <tag>1.21.0</tag>
+        <tag>1.17.1</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.noconnor</groupId>
     <artifactId>junitperf-parent</artifactId>
-    <version>1.21.0-SNAPSHOT</version>
+    <version>1.21.0</version>
     <packaging>pom</packaging>
 
     <name>junitperf</name>
@@ -208,7 +208,7 @@
         <connection>scm:git:ssh://git@github.com:noconnor/JUnitPerf.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:noconnor/JUnitPerf.git</developerConnection>
         <url>git@github.com:noconnor/JUnitPerf.git</url>
-        <tag>1.17.1</tag>
+        <tag>1.21.0</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.noconnor</groupId>
     <artifactId>junitperf-parent</artifactId>
-    <version>1.20.0-SNAPSHOT</version>
+    <version>1.20.0</version>
     <packaging>pom</packaging>
 
     <name>junitperf</name>
@@ -208,7 +208,7 @@
         <connection>scm:git:ssh://git@github.com:noconnor/JUnitPerf.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:noconnor/JUnitPerf.git</developerConnection>
         <url>git@github.com:noconnor/JUnitPerf.git</url>
-        <tag>1.17.1</tag>
+        <tag>1.20.0</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.noconnor</groupId>
     <artifactId>junitperf-parent</artifactId>
-    <version>1.20.0</version>
+    <version>1.21.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>junitperf</name>
@@ -208,7 +208,7 @@
         <connection>scm:git:ssh://git@github.com:noconnor/JUnitPerf.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:noconnor/JUnitPerf.git</developerConnection>
         <url>git@github.com:noconnor/JUnitPerf.git</url>
-        <tag>1.20.0</tag>
+        <tag>1.17.1</tag>
     </scm>
 
     <licenses>


### PR DESCRIPTION
Fixes issue where test threads are not terminated because interrupt status is swallowed by evaluation task

## Proposed Changes

  - Add atomic boolean stop signal to evaluation tasks
  - Test shutdown should set stop signal flag as well as interrupt threads
 
