### PR TITLE
Upgrading lombok to fix jdk17 issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <mockito.version>3.8.0</mockito.version>
         <hamcrest.version>2.0.0.0</hamcrest.version>
-        <lombok.version>1.18.18</lombok.version>
+        <lombok.version>1.18.24</lombok.version>
         <commons.lang3.version>3.11</commons.lang3.version>
         <logback.classic.version>1.3.0</logback.classic.version>
         <guava.version>30.1-jre</guava.version>


### PR DESCRIPTION
Fixes JDK17 issue:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:testCompile (default-testCompile) on project lsbe-hv: Fatal error compiling: java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor (in unnamed module @0x681f01aa) cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module @0x681f01aa -> [Help 1]
```

## Proposed Changes

  - Update lombok to 1.18.24
  - https://projectlombok.org/changelog
  - https://stackoverflow.com/a/66981165
