### PR TITLE
Fix for proceed when perf test enabled

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: master # Switch back to master: see GITHUB_SHA https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:
@@ -21,7 +20,9 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Setup git config
-        run: |          
+        run: |  
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          git checkout -b version-update-${LATEST_TAG}
           git config user.name "github-actions[release]"
           git config user.email "github-actions[release]@users.noreply.github.com"
       - name: Publish package
@@ -31,4 +32,4 @@ jobs:
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Push Pom Version Updates
-        run: git push # see docs on actions/checkout
+        uses: peter-evans/create-pull-request@v5

--- a/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
+++ b/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
@@ -100,13 +100,13 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
                     .build();
 
             parallelExecution.runParallelEvaluation();
-        }
-        try {
-            // Must be called for framework to proceed
+
+            proceedQuietly(invocation);
+
+        } else {
             invocation.proceed();
-        } catch (Exception e) {
-            // Ignore
         }
+        
     }
 
     @Override
@@ -118,7 +118,6 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
         return new TestContextSupplier(measurementsStartTimeMs, activeStatisticsCalculator);
     }
-
 
     protected JUnitPerfTestRequirement getJUnitPerfTestRequirementDetails(Method method, ExtensionContext ctxt) {
         JUnitPerfTestRequirement methodAnnotation = method.getAnnotation(JUnitPerfTestRequirement.class);
@@ -175,6 +174,15 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
             }
         }
         return scanForReportingConfig(testInstance, testClass.getSuperclass());
+    }
+
+    private static void proceedQuietly(Invocation<Void> invocation) throws Throwable {
+        try {
+            // Must be called for framework to proceed
+            invocation.proceed();
+        } catch (Throwable e) {
+            // Ignore
+        }
     }
 
 }

--- a/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/JUnitPerfInterceptorTest.java
+++ b/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/JUnitPerfInterceptorTest.java
@@ -262,6 +262,54 @@ class JUnitPerfInterceptorTest {
     }
 
     @Test
+    void whenProceedThrowsAnAssertionError_thenTestShouldNotFail() throws Throwable {
+        SampleAnnotatedTest test = new SampleAnnotatedTest();
+
+        Method methodMock = test.getClass().getMethod("someTestMethod");
+        PerformanceEvaluationStatement statementMock = mock(PerformanceEvaluationStatement.class);
+        Invocation<Void> invocationMock = mock(Invocation.class);
+        ReflectiveInvocationContext<Method> invocationContextMock = mock(ReflectiveInvocationContext.class);
+        ExtensionContext extensionContextMock = mockTestContext();
+
+        when(extensionContextMock.getRequiredTestMethod()).thenReturn(methodMock);
+        when(extensionContextMock.getRequiredTestClass()).thenReturn((Class) test.getClass());
+        when(statementBuilderMock.build()).thenReturn(statementMock);
+
+        when(invocationMock.proceed()).thenThrow(new AssertionError());
+        
+        interceptor.postProcessTestInstance(test, extensionContextMock);
+        interceptor.statementBuilder = statementBuilderMock;
+        
+        assertDoesNotThrow(() -> {
+            interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
+        });
+    }
+
+    @Test
+    void whenProceedThrowsAnAssertionError_andTestIsNotAPerfTest_thenTestShouldFail() throws Throwable {
+        SampleNoAnnotationsTest test = new SampleNoAnnotationsTest();
+
+        Method methodMock = test.getClass().getMethod("someTestMethod");
+        PerformanceEvaluationStatement statementMock = mock(PerformanceEvaluationStatement.class);
+        Invocation<Void> invocationMock = mock(Invocation.class);
+        ReflectiveInvocationContext<Method> invocationContextMock = mock(ReflectiveInvocationContext.class);
+        ExtensionContext extensionContextMock = mockTestContext();
+
+        when(extensionContextMock.getRequiredTestMethod()).thenReturn(methodMock);
+        when(extensionContextMock.getRequiredTestClass()).thenReturn((Class) test.getClass());
+        when(statementBuilderMock.build()).thenReturn(statementMock);
+
+        when(invocationMock.proceed()).thenThrow(new AssertionError());
+
+        interceptor.postProcessTestInstance(test, extensionContextMock);
+        interceptor.statementBuilder = statementBuilderMock;
+
+        assertThrows(AssertionError.class, () -> {
+            interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
+        });
+    }
+
+    @Test
     void whenInterceptorSupportsParameterIsCalled_thenParameterTypeShouldBeChecked() throws NoSuchMethodException {
         assertTrue(interceptor.supportsParameter(mockTestContextSupplierParameterType(), null));
         assertFalse(interceptor.supportsParameter(mockStringParameterType(), null));


### PR DESCRIPTION
Fixes issue where call to proceed can fail test even though perf thresholds have been met

## Proposed Changes

  - Catch throwable instead of Exception when calling invocation.proceed()
