### PR TITLE
Refactoring interceptor

### DIFF
--- a/docs/junit5.md
+++ b/docs/junit5.md
@@ -214,7 +214,7 @@ private final static JUnitPerfReportingConfig PERF_CONFIG = JUnitPerfReportingCo
         .build();
 ```
 
-**NOTE:** the `JUnitPerfReportingConfig` should be a **static** field instance to prevent a new/different instance being created for each `@Test`
+**NOTE:** the `JUnitPerfReportingConfig` must be a **static** field instance to prevent a new/different instance being created for each `@Test`
 instance
 
 To generate an **CSV report**

--- a/junit5-examples/pom.xml
+++ b/junit5-examples/pom.xml
@@ -43,6 +43,12 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skipTests>${skipTests}</skipTests>
+<!--                    <properties>-->
+<!--                        <configurationParameters>-->
+<!--                            junit.jupiter.execution.parallel.enabled = true-->
+<!--                            junit.jupiter.execution.parallel.mode.default = concurrent-->
+<!--                        </configurationParameters>-->
+<!--                    </properties>-->
                 </configuration>
             </plugin>
         </plugins>

--- a/junitperf-core/src/main/java/com/github/noconnor/junitperf/reporting/providers/HtmlReportGenerator.java
+++ b/junitperf-core/src/main/java/com/github/noconnor/junitperf/reporting/providers/HtmlReportGenerator.java
@@ -57,7 +57,7 @@ public class HtmlReportGenerator implements ReportGenerator {
     }
 
     @Override
-    public void generateReport(LinkedHashSet<EvaluationContext> testContexts) {
+    public synchronized void generateReport(LinkedHashSet<EvaluationContext> testContexts) {
         history.addAll(testContexts);
         renderTemplate();
     }

--- a/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
+++ b/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
@@ -149,10 +149,10 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
         });
     }
 
-    private static void warnIfNonStatic(Field field) {
+    private static void failIfNonStatic(Field field) {
         boolean isStatic = Modifier.isStatic(field.getModifiers());
         if (!isStatic) {
-            log.warn("Warning: JUnitPerfTestConfig should be static or a new instance will be created for each @Test method");
+            throw new IllegalStateException("JUnitPerfTestConfig should be static ");
         }
     }
 
@@ -168,7 +168,7 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
         }
         for (Field field : testClass.getDeclaredFields()) {
             if (field.isAnnotationPresent(JUnitPerfTestActiveConfig.class)) {
-                warnIfNonStatic(field);
+                failIfNonStatic(field);
                 field.setAccessible(true);
                 return (JUnitPerfReportingConfig) field.get(testInstance);
             }

--- a/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
+++ b/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
@@ -9,6 +9,7 @@ import com.github.noconnor.junitperf.statements.SimpleTestStatement;
 import com.github.noconnor.junitperf.statistics.StatisticsCalculator;
 import com.github.noconnor.junitperf.statistics.providers.DescriptiveStatisticsCalculator;
 import com.github.noconnor.junitperf.suite.SuiteRegistry;
+import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
@@ -25,6 +26,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 import static java.lang.System.currentTimeMillis;
 import static java.lang.System.nanoTime;
@@ -36,40 +38,50 @@ import static java.util.Objects.nonNull;
 public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstancePostProcessor, ParameterResolver {
 
     protected static final ReportGenerator DEFAULT_REPORTER = new ConsoleReportGenerator();
-    protected static final Map<String, LinkedHashSet<EvaluationContext>> ACTIVE_CONTEXTS = new ConcurrentHashMap<>();
+    protected static final Map<String, TestDetails> testContexts = new ConcurrentHashMap<>();
+    protected static final Map<String, SharedConfig> sharedContexts = new ConcurrentHashMap<>();
 
-    protected Collection<ReportGenerator> activeReporters;
-    protected StatisticsCalculator activeStatisticsCalculator;
-    protected long measurementsStartTimeMs;
-    protected PerformanceEvaluationStatementBuilder statementBuilder;
+    @Data
+    protected static class TestDetails {
+        private Class<?> testClass;
+        private Method testMethod;
+        private long measurementsStartTimeMs;
+        private EvaluationContext context;
+        private StatisticsCalculator statsCalculator;
+        private Collection<ReportGenerator> activeReporters;
+        private PerformanceEvaluationStatementBuilder statementBuilder;
+    }
 
-
+    @Data
+    protected static class SharedConfig {
+        private Collection<ReportGenerator> activeReporters = singletonList(DEFAULT_REPORTER);
+        private Supplier<StatisticsCalculator> statsSupplier = DescriptiveStatisticsCalculator::new;
+        private PerformanceEvaluationStatementBuilder statementBuilder = PerformanceEvaluationStatement.builder();
+    }
+    
     @Override
-    public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
-
-        SuiteRegistry.register(context);
-
+    public synchronized void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
+        if (sharedContexts.containsKey(context.getUniqueId())) {
+            log.debug("Test already configured");
+            return;
+        }
+        
+        SharedConfig test = new SharedConfig();
+        SuiteRegistry.scanForSuiteDetails(context);
         JUnitPerfReportingConfig reportingConfig = findTestActiveConfigField(testInstance, context);
-
         if (nonNull(reportingConfig)) {
-            activeReporters = reportingConfig.getReportGenerators();
-            activeStatisticsCalculator = reportingConfig.getStatisticsCalculatorSupplier().get();
+            test.setActiveReporters(reportingConfig.getReportGenerators());
+            test.setStatsSupplier(reportingConfig.getStatisticsCalculatorSupplier());
         }
-
-        // Defaults if no overrides provided
-        if (isNull(activeReporters) || activeReporters.isEmpty()) {
-            activeReporters = singletonList(DEFAULT_REPORTER);
-        }
-        if (isNull(activeStatisticsCalculator)) {
-            activeStatisticsCalculator = new DescriptiveStatisticsCalculator();
-        }
-        statementBuilder = PerformanceEvaluationStatement.builder();
+        sharedContexts.put(context.getUniqueId(), test);
     }
 
     @Override
     public void interceptTestMethod(Invocation<Void> invocation,
                                     ReflectiveInvocationContext<Method> invocationContext,
                                     ExtensionContext extensionContext) throws Throwable {
+        
+
         // Will be called for every instance of @Test
         Method method = extensionContext.getRequiredTestMethod();
 
@@ -77,26 +89,28 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
         JUnitPerfTestRequirement requirementsAnnotation = getJUnitPerfTestRequirementDetails(method, extensionContext);
 
         if (nonNull(perfTestAnnotation)) {
-            measurementsStartTimeMs = currentTimeMillis() + perfTestAnnotation.warmUpMs();
-            boolean isAsync = invocationContext.getArguments().stream().anyMatch(arg -> arg instanceof TestContextSupplier);
 
+            boolean isAsync = invocationContext.getArguments().stream().anyMatch(arg -> arg instanceof TestContextSupplier);
             EvaluationContext context = createEvaluationContext(method, isAsync);
             context.loadConfiguration(perfTestAnnotation);
             context.loadRequirements(requirementsAnnotation);
 
-            ACTIVE_CONTEXTS.putIfAbsent(extensionContext.getUniqueId(), new LinkedHashSet<>());
-            ACTIVE_CONTEXTS.get(extensionContext.getUniqueId()).add(context);
+            TestDetails test = getTestDetails(extensionContext);
+            test.setTestClass(method.getDeclaringClass());
+            test.setTestMethod(method);
+            test.setMeasurementsStartTimeMs(currentTimeMillis() + perfTestAnnotation.warmUpMs());
+            test.setContext(context);
 
             SimpleTestStatement testStatement = () -> method.invoke(
                     extensionContext.getRequiredTestInstance(),
                     invocationContext.getArguments().toArray()
             );
 
-            PerformanceEvaluationStatement parallelExecution = statementBuilder
+            PerformanceEvaluationStatement parallelExecution = test.getStatementBuilder()
                     .baseStatement(testStatement)
-                    .statistics(activeStatisticsCalculator)
+                    .statistics(test.getStatsCalculator())
                     .context(context)
-                    .listener(complete -> updateReport(extensionContext))
+                    .listener(complete -> updateReport(test))
                     .build();
 
             parallelExecution.runParallelEvaluation();
@@ -106,9 +120,9 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
         } else {
             invocation.proceed();
         }
-        
-    }
 
+    }
+    
     @Override
     public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
         return parameterContext.getParameter().getType() == TestContextSupplier.class;
@@ -116,7 +130,8 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
 
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-        return new TestContextSupplier(measurementsStartTimeMs, activeStatisticsCalculator);
+        TestDetails test = getTestDetails(extensionContext);
+        return new TestContextSupplier(test.getMeasurementsStartTimeMs(), test.getStatsCalculator());
     }
 
     protected JUnitPerfTestRequirement getJUnitPerfTestRequirementDetails(Method method, ExtensionContext ctxt) {
@@ -143,9 +158,11 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
         return ctx;
     }
 
-    private synchronized void updateReport(ExtensionContext ctxt) {
-        activeReporters.forEach(r -> {
-            r.generateReport(ACTIVE_CONTEXTS.get(ctxt.getUniqueId()));
+    private synchronized void updateReport(TestDetails test) {
+        test.getActiveReporters().forEach(r -> {
+            LinkedHashSet<EvaluationContext> ctxt = new LinkedHashSet<>();
+            ctxt.add(test.getContext());
+            r.generateReport(ctxt);
         });
     }
 
@@ -185,4 +202,18 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
         }
     }
 
+    private static TestDetails getTestDetails(ExtensionContext extensionContext) {
+        String testId  = extensionContext.getUniqueId();
+        testContexts.computeIfAbsent(testId, newTestId -> {
+            String parentId = extensionContext.getParent().map(ExtensionContext::getUniqueId).orElse(null);
+            SharedConfig parentDetails = sharedContexts.getOrDefault(parentId, new SharedConfig());
+            TestDetails testDetails = new TestDetails();
+            testDetails.setStatementBuilder(parentDetails.getStatementBuilder());
+            testDetails.setActiveReporters(parentDetails.getActiveReporters());
+            testDetails.setStatsCalculator(parentDetails.getStatsSupplier().get());
+            return testDetails;
+        });
+        return testContexts.get(testId);
+    }
+    
 }

--- a/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
+++ b/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
@@ -56,7 +56,7 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
     protected static class SharedConfig {
         private Collection<ReportGenerator> activeReporters = singletonList(DEFAULT_REPORTER);
         private Supplier<StatisticsCalculator> statsSupplier = DescriptiveStatisticsCalculator::new;
-        private PerformanceEvaluationStatementBuilder statementBuilder = PerformanceEvaluationStatement.builder();
+        private Supplier<PerformanceEvaluationStatementBuilder> statementBuilder = PerformanceEvaluationStatement::builder;
     }
     
     @Override
@@ -208,7 +208,7 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
             String parentId = extensionContext.getParent().map(ExtensionContext::getUniqueId).orElse(null);
             SharedConfig parentDetails = sharedContexts.getOrDefault(parentId, new SharedConfig());
             TestDetails testDetails = new TestDetails();
-            testDetails.setStatementBuilder(parentDetails.getStatementBuilder());
+            testDetails.setStatementBuilder(parentDetails.getStatementBuilder().get());
             testDetails.setActiveReporters(parentDetails.getActiveReporters());
             testDetails.setStatsCalculator(parentDetails.getStatsSupplier().get());
             return testDetails;

--- a/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
+++ b/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
@@ -205,7 +205,7 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
     private static TestDetails getTestDetails(ExtensionContext extensionContext) {
         String testId  = extensionContext.getUniqueId();
         testContexts.computeIfAbsent(testId, newTestId -> {
-            String parentId = extensionContext.getParent().map(ExtensionContext::getUniqueId).orElse(null);
+            String parentId = extensionContext.getParent().map(ExtensionContext::getUniqueId).orElse("");
             SharedConfig parentDetails = sharedContexts.getOrDefault(parentId, new SharedConfig());
             TestDetails testDetails = new TestDetails();
             testDetails.setStatementBuilder(parentDetails.getStatementBuilder().get());

--- a/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/suite/SuiteRegistry.java
+++ b/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/suite/SuiteRegistry.java
@@ -27,7 +27,7 @@ public class SuiteRegistry {
     private static final Map<String, SuiteSettings> settingsCache = new HashMap<>();
     private static final Pattern suiteClassPattern = Pattern.compile(".*\\[suite:([^\\]]*)\\].*");
 
-    public static void register(ExtensionContext context) {
+    public static void scanForSuiteDetails(ExtensionContext context) {
 
         String rootUniqueId = getRootId(context);
         Class<?> clazz = getSuiteClass(rootUniqueId);

--- a/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/JUnitPerfInterceptorTest.java
+++ b/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/JUnitPerfInterceptorTest.java
@@ -310,6 +310,19 @@ class JUnitPerfInterceptorTest {
     }
 
     @Test
+    void whenReportingConfigIsNonStatic_thenPostProcessTestInstanceShouldThrowAnException() throws Throwable {
+        SampleNonStaticReporterConfigTest test = new SampleNonStaticReporterConfigTest();
+
+        Method methodMock = test.getClass().getMethod("someTestMethod");
+        ExtensionContext extensionContextMock = mockTestContext();
+
+        when(extensionContextMock.getRequiredTestMethod()).thenReturn(methodMock);
+        when(extensionContextMock.getRequiredTestClass()).thenReturn((Class) test.getClass());
+        
+        assertThrows( IllegalStateException.class, () -> interceptor.postProcessTestInstance(test, extensionContextMock));
+    }
+
+    @Test
     void whenInterceptorSupportsParameterIsCalled_thenParameterTypeShouldBeChecked() throws NoSuchMethodException {
         assertTrue(interceptor.supportsParameter(mockTestContextSupplierParameterType(), null));
         assertFalse(interceptor.supportsParameter(mockStringParameterType(), null));
@@ -445,6 +458,19 @@ class JUnitPerfInterceptorTest {
     @JUnitPerfTest( threads = 15, totalExecutions = 120)
     @JUnitPerfTestRequirement(executionsPerSec = 67)
     public static class SampleChildTest extends SampleBaseTest {
+        @Test
+        public void someTestMethod() {
+            assertTrue(true);
+        }
+    }
+
+    @Disabled
+    public static class SampleNonStaticReporterConfigTest {
+        @JUnitPerfTestActiveConfig
+        public final JUnitPerfReportingConfig config = JUnitPerfReportingConfig.builder()
+                .reportGenerator(new HtmlReportGenerator())
+                .build();
+
         @Test
         public void someTestMethod() {
             assertTrue(true);

--- a/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/JUnitPerfInterceptorTest.java
+++ b/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/JUnitPerfInterceptorTest.java
@@ -1,5 +1,7 @@
 package com.github.noconnor.junitperf;
 
+import com.github.noconnor.junitperf.JUnitPerfInterceptor.SharedConfig;
+import com.github.noconnor.junitperf.JUnitPerfInterceptor.TestDetails;
 import com.github.noconnor.junitperf.data.EvaluationContext;
 import com.github.noconnor.junitperf.reporting.ReportGenerator;
 import com.github.noconnor.junitperf.reporting.providers.ConsoleReportGenerator;
@@ -27,12 +29,22 @@ import org.mockito.quality.Strictness;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.singletonList;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 class JUnitPerfInterceptorTest {
@@ -45,7 +57,8 @@ class JUnitPerfInterceptorTest {
     @BeforeEach
     void setup() {
         SuiteRegistry.clearRegistry();
-        JUnitPerfInterceptor.ACTIVE_CONTEXTS.clear();
+        JUnitPerfInterceptor.testContexts.clear();
+        JUnitPerfInterceptor.sharedContexts.clear();
         interceptor = new JUnitPerfInterceptor();
     }
     
@@ -56,69 +69,76 @@ class JUnitPerfInterceptorTest {
 
     @Test
     void whenATestClassHasNoReportingOverrides_thenDefaultReportingConfigsShouldBeSet() throws Exception {
-        assertNull(interceptor.activeStatisticsCalculator);
-        assertNull(interceptor.activeReporters);
+        ExtensionContext context = mockTestContext();
+        assertNull(getSharedContext(context));
+        
+        interceptor.postProcessTestInstance(new SampleTestNoReportingOverrides(), getParent(context));
 
-        interceptor.postProcessTestInstance(new SampleTestNoReportingOverrides(), null);
-
-        assertTrue(interceptor.activeStatisticsCalculator instanceof DescriptiveStatisticsCalculator);
-        assertEquals(1, interceptor.activeReporters.size());
-        assertEquals(JUnitPerfInterceptor.DEFAULT_REPORTER, interceptor.activeReporters.toArray()[0]);
+        SharedConfig shared = getSharedContext(context);
+        
+        assertTrue(shared.getStatsSupplier().get() instanceof DescriptiveStatisticsCalculator);
+        assertEquals(1, shared.getActiveReporters().size());
+        assertEquals(JUnitPerfInterceptor.DEFAULT_REPORTER, shared.getActiveReporters().toArray()[0]);
     }
-
+    
     @SuppressWarnings("InstantiationOfUtilityClass")
     @Test
     void whenATestClassHasReportingOverrides_butOverridesAreMissingAnnotation_thenDefaultReportingConfigsShouldBeSet() throws Exception {
-        assertNull(interceptor.activeStatisticsCalculator);
-        assertNull(interceptor.activeReporters);
+        ExtensionContext context = mockTestContext();
+        assertNull(getSharedContext(context));
 
-        interceptor.postProcessTestInstance(new SampleTestWithReportingOverridesMissingAnnotation(), null);
+        interceptor.postProcessTestInstance(new SampleTestWithReportingOverridesMissingAnnotation(), getParent(context));
 
-        assertTrue(interceptor.activeStatisticsCalculator instanceof DescriptiveStatisticsCalculator);
-        assertEquals(1, interceptor.activeReporters.size());
-        assertEquals(JUnitPerfInterceptor.DEFAULT_REPORTER, interceptor.activeReporters.toArray()[0]);
+        SharedConfig shared = getSharedContext(context);
+        assertTrue(shared.getStatsSupplier().get() instanceof DescriptiveStatisticsCalculator);
+        assertEquals(1, shared.getActiveReporters().size());
+        assertEquals(JUnitPerfInterceptor.DEFAULT_REPORTER, shared.getActiveReporters().toArray()[0]);
     }
 
     @SuppressWarnings("InstantiationOfUtilityClass")
     @Test
     void whenATestClassHasReportingOverrides_thenOverridesShouldBeAccepted() throws Exception {
-        assertNull(interceptor.activeStatisticsCalculator);
-        assertNull(interceptor.activeReporters);
+        ExtensionContext context = mockTestContext();
+        assertNull(getSharedContext(context));
 
-        interceptor.postProcessTestInstance(new SampleTestWithReportingOverrides(), null);
+        interceptor.postProcessTestInstance(new SampleTestWithReportingOverrides(), getParent(context));
 
-        assertTrue(interceptor.activeStatisticsCalculator instanceof DescriptiveStatisticsCalculator);
-        assertEquals(1, interceptor.activeReporters.size());
-        assertEquals(SampleTestWithReportingOverrides.REPORTER, interceptor.activeReporters.toArray()[0]);
+        SharedConfig shared = getSharedContext(context);
+        assertTrue(shared.getStatsSupplier().get() instanceof DescriptiveStatisticsCalculator);
+        assertEquals(1, shared.getActiveReporters().size());
+        assertEquals(SampleTestWithReportingOverrides.REPORTER, shared.getActiveReporters().toArray()[0]);
     }
 
     @SuppressWarnings("InstantiationOfUtilityClass")
     @Test
     void whenATestClassHasReportingAndStatsOverrides_thenOverridesShouldBeAccepted() throws Exception {
-        assertNull(interceptor.activeStatisticsCalculator);
-        assertNull(interceptor.activeReporters);
+        ExtensionContext context = mockTestContext();
+        assertNull(getSharedContext(context));
 
-        interceptor.postProcessTestInstance(new SampleTestWithReportingAndStatisticsOverrides(), null);
+        interceptor.postProcessTestInstance(new SampleTestWithReportingAndStatisticsOverrides(), getParent(context));
 
-        assertEquals(SampleTestWithReportingAndStatisticsOverrides.CALCULATOR, interceptor.activeStatisticsCalculator);
-        assertEquals(1, interceptor.activeReporters.size());
-        assertEquals(SampleTestWithReportingAndStatisticsOverrides.REPORTER, interceptor.activeReporters.toArray()[0]);
+        SharedConfig shared = getSharedContext(context);
+        assertEquals(SampleTestWithReportingAndStatisticsOverrides.CALCULATOR, shared.getStatsSupplier().get());
+        assertEquals(1, shared.getActiveReporters().size());
+        assertEquals(SampleTestWithReportingAndStatisticsOverrides.REPORTER, shared.getActiveReporters().toArray()[0]);
     }
-
 
     @SuppressWarnings("unchecked")
     @Test
     void whenTestHasNotBeenAnnotatedWithPerfAnnotations_thenTestWillBeExecutedOnce() throws Throwable {
+        ExtensionContext extensionContextMock = mockTestContext();
+        assertNull(getSharedContext(extensionContextMock));
+        
         SampleNoAnnotationsTest test = new SampleNoAnnotationsTest();
 
         Method methodMock = test.getClass().getMethod("someTestMethod");
         Invocation<Void> invocationMock = mock(Invocation.class);
         ReflectiveInvocationContext<Method> invocationContextMock = mock(ReflectiveInvocationContext.class);
-        ExtensionContext extensionContextMock = mockTestContext();
         when(extensionContextMock.getRequiredTestMethod()).thenReturn(methodMock);
 
-        interceptor.postProcessTestInstance(test, null);
-        interceptor.statementBuilder = statementBuilderMock;
+        interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
+        // Override statement builder
+        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
         interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
 
         verify(invocationMock).proceed();
@@ -128,26 +148,29 @@ class JUnitPerfInterceptorTest {
     @SuppressWarnings("unchecked")
     @Test
     void whenTestHasBeenAnnotatedWithPerfAnnotations_thenTestStatementShouldBeBuilt() throws Throwable {
+        ExtensionContext extensionContextMock = mockTestContext();
+        assertNull(getSharedContext(extensionContextMock));
+        
         SampleAnnotatedTest test = new SampleAnnotatedTest();
 
         Method methodMock = test.getClass().getMethod("someTestMethod");
         PerformanceEvaluationStatement statementMock = mock(PerformanceEvaluationStatement.class);
         Invocation<Void> invocationMock = mock(Invocation.class);
         ReflectiveInvocationContext<Method> invocationContextMock = mock(ReflectiveInvocationContext.class);
-        ExtensionContext extensionContextMock = mockTestContext();
 
         when(extensionContextMock.getRequiredTestMethod()).thenReturn(methodMock);
         when(extensionContextMock.getRequiredTestClass()).thenReturn((Class) test.getClass());
         when(statementBuilderMock.build()).thenReturn(statementMock);
 
-        interceptor.postProcessTestInstance(test, null);
-        interceptor.statementBuilder = statementBuilderMock;
+        interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
+        // Override statement builder
+        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
         interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
 
         verify(invocationMock).proceed();
         verify(statementMock).runParallelEvaluation();
 
-        assertEquals(1, JUnitPerfInterceptor.ACTIVE_CONTEXTS.get(extensionContextMock.getUniqueId()).size());
+        assertNotNull(getTestContext(extensionContextMock));
         EvaluationContext context = captureEvaluationContext();
         assertFalse(context.isAsyncEvaluation());
     }
@@ -155,44 +178,53 @@ class JUnitPerfInterceptorTest {
     @SuppressWarnings("unchecked")
     @Test
     void whenTestHasBeenAnnotatedWithPerfAnnotations_thenMeasurementStartMsShouldBeCaptured() throws Throwable {
+        ExtensionContext extensionContextMock = mockTestContext();
+        assertNull(getSharedContext(extensionContextMock));
+
         SampleAnnotatedTest test = new SampleAnnotatedTest();
 
         Method methodMock = test.getClass().getMethod("someTestMethod");
         PerformanceEvaluationStatement statementMock = mock(PerformanceEvaluationStatement.class);
         Invocation<Void> invocationMock = mock(Invocation.class);
         ReflectiveInvocationContext<Method> invocationContextMock = mock(ReflectiveInvocationContext.class);
-        ExtensionContext extensionContextMock = mockTestContext();
 
         when(extensionContextMock.getRequiredTestMethod()).thenReturn(methodMock);
         when(extensionContextMock.getRequiredTestClass()).thenReturn((Class) test.getClass());
         when(statementBuilderMock.build()).thenReturn(statementMock);
 
-        interceptor.postProcessTestInstance(test, null);
-        interceptor.statementBuilder = statementBuilderMock;
+        interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
+        
+        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
+        
         interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
 
-        assertTrue(interceptor.measurementsStartTimeMs > 0);
-        assertTrue(interceptor.measurementsStartTimeMs <= currentTimeMillis() + 100); // see warmUpMs in annotation
+        TestDetails testDetails = getTestContext(extensionContextMock);
+        assertTrue(testDetails.getMeasurementsStartTimeMs() > 0);
+        assertTrue(testDetails.getMeasurementsStartTimeMs() <= currentTimeMillis() + 100); // see warmUpMs in annotation
     }
     
     @SuppressWarnings("unchecked")
     @Test
     void whenAsyncTestHasBeenAnnotatedWithPerfAnnotations_thenContextShouldBeMarkedAsAsync() throws Throwable {
+        ExtensionContext extensionContextMock = mockTestContext();
+        assertNull(getSharedContext(extensionContextMock));
+        
         SampleAsyncAnnotatedTest test = new SampleAsyncAnnotatedTest();
 
         Method methodMock = test.getClass().getMethod("someTestMethod", TestContextSupplier.class);
         PerformanceEvaluationStatement statementMock = mock(PerformanceEvaluationStatement.class);
         Invocation<Void> invocationMock = mock(Invocation.class);
         ReflectiveInvocationContext<Method> invocationContextMock = mock(ReflectiveInvocationContext.class);
-        ExtensionContext extensionContextMock = mockTestContext();
 
         when(invocationContextMock.getArguments()).thenReturn(mockAsyncArgs());
         when(extensionContextMock.getRequiredTestMethod()).thenReturn(methodMock);
         when(extensionContextMock.getUniqueId()).thenReturn(test.getClass().getSimpleName());
         when(statementBuilderMock.build()).thenReturn(statementMock);
 
-        interceptor.postProcessTestInstance(test, null);
-        interceptor.statementBuilder = statementBuilderMock;
+        interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
+
+        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
+
         interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
 
         EvaluationContext context = captureEvaluationContext();
@@ -201,28 +233,33 @@ class JUnitPerfInterceptorTest {
 
     @Test
     void whenASuiteAnnotationsAreAvailable_thenSuiteAnnotationsShouldBeUsed() throws Throwable {
+        ExtensionContext extensionContextMock = mockTestContext();
+        assertNull(getSharedContext(extensionContextMock));
+
         SampleNoAnnotationsTest test = new SampleNoAnnotationsTest();
         
         Method methodMock = test.getClass().getMethod("someTestMethod");
         PerformanceEvaluationStatement statementMock = mock(PerformanceEvaluationStatement.class);
         Invocation<Void> invocationMock = mock(Invocation.class);
         ReflectiveInvocationContext<Method> invocationContextMock = mock(ReflectiveInvocationContext.class);
-        ExtensionContext extensionContextMock = mockTestContext();
         mockActiveSuite(extensionContextMock, SuiteSampleTest.class);
-
-
+        
         when(extensionContextMock.getRequiredTestMethod()).thenReturn(methodMock);
         when(extensionContextMock.getRequiredTestClass()).thenReturn((Class) test.getClass());
         when(statementBuilderMock.build()).thenReturn(statementMock);
 
-        interceptor.postProcessTestInstance(test, extensionContextMock);
-        interceptor.statementBuilder = statementBuilderMock;
+        interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
+
+        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
+
         interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
 
-        assertTrue(interceptor.measurementsStartTimeMs > 0);
+        TestDetails testDetails = getTestContext(extensionContextMock);
+
+        assertTrue(testDetails.getMeasurementsStartTimeMs() > 0);
         
-        assertEquals(1, interceptor.activeReporters.size());
-        assertEquals(SuiteSampleTest.config.getReportGenerators(), interceptor.activeReporters);
+        assertEquals(1, testDetails.getActiveReporters().size());
+        assertEquals(SuiteSampleTest.config.getReportGenerators(), testDetails.getActiveReporters());
         
         EvaluationContext context = captureEvaluationContext();
         assertEquals(100, context.getConfiguredExecutionTarget());
@@ -233,26 +270,32 @@ class JUnitPerfInterceptorTest {
 
     @Test
     void whenAChildClassInheritsFromABaseClassWithReportingConfig_thenChildClassShouldHaveAccessToReportingConfig() throws Throwable {
+        ExtensionContext extensionContextMock = mockTestContext();
+        assertNull(getSharedContext(extensionContextMock));
+
         SampleChildTest test = new SampleChildTest();
 
         Method methodMock = test.getClass().getMethod("someTestMethod");
         PerformanceEvaluationStatement statementMock = mock(PerformanceEvaluationStatement.class);
         Invocation<Void> invocationMock = mock(Invocation.class);
         ReflectiveInvocationContext<Method> invocationContextMock = mock(ReflectiveInvocationContext.class);
-        ExtensionContext extensionContextMock = mockTestContext();
 
         when(extensionContextMock.getRequiredTestMethod()).thenReturn(methodMock);
         when(extensionContextMock.getRequiredTestClass()).thenReturn((Class) test.getClass());
         when(statementBuilderMock.build()).thenReturn(statementMock);
 
-        interceptor.postProcessTestInstance(test, extensionContextMock);
-        interceptor.statementBuilder = statementBuilderMock;
+        interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
+
+        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
+
         interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
 
-        assertTrue(interceptor.measurementsStartTimeMs > 0);
+        TestDetails testDetails = getTestContext(extensionContextMock);
 
-        assertEquals(1, interceptor.activeReporters.size());
-        assertEquals( SampleBaseTest.config.getReportGenerators(), interceptor.activeReporters);
+        assertTrue(testDetails.getMeasurementsStartTimeMs() > 0);
+
+        assertEquals(1, testDetails.getActiveReporters().size());
+        assertEquals(SampleBaseTest.config.getReportGenerators(), testDetails.getActiveReporters());
 
         EvaluationContext context = captureEvaluationContext();
         assertEquals(120, context.getConfiguredExecutionTarget());
@@ -263,37 +306,42 @@ class JUnitPerfInterceptorTest {
 
     @Test
     void whenProceedThrowsAnAssertionError_thenTestShouldNotFail() throws Throwable {
+        ExtensionContext extensionContextMock = mockTestContext();
+        assertNull(getSharedContext(extensionContextMock));
+
         SampleAnnotatedTest test = new SampleAnnotatedTest();
 
         Method methodMock = test.getClass().getMethod("someTestMethod");
         PerformanceEvaluationStatement statementMock = mock(PerformanceEvaluationStatement.class);
         Invocation<Void> invocationMock = mock(Invocation.class);
         ReflectiveInvocationContext<Method> invocationContextMock = mock(ReflectiveInvocationContext.class);
-        ExtensionContext extensionContextMock = mockTestContext();
 
         when(extensionContextMock.getRequiredTestMethod()).thenReturn(methodMock);
         when(extensionContextMock.getRequiredTestClass()).thenReturn((Class) test.getClass());
         when(statementBuilderMock.build()).thenReturn(statementMock);
 
         when(invocationMock.proceed()).thenThrow(new AssertionError());
-        
-        interceptor.postProcessTestInstance(test, extensionContextMock);
-        interceptor.statementBuilder = statementBuilderMock;
+
+        interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
+
+        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
         
         assertDoesNotThrow(() -> {
             interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
         });
     }
-
+    
     @Test
     void whenProceedThrowsAnAssertionError_andTestIsNotAPerfTest_thenTestShouldFail() throws Throwable {
+        ExtensionContext extensionContextMock = mockTestContext();
+        assertNull(getSharedContext(extensionContextMock));
+
         SampleNoAnnotationsTest test = new SampleNoAnnotationsTest();
 
         Method methodMock = test.getClass().getMethod("someTestMethod");
         PerformanceEvaluationStatement statementMock = mock(PerformanceEvaluationStatement.class);
         Invocation<Void> invocationMock = mock(Invocation.class);
         ReflectiveInvocationContext<Method> invocationContextMock = mock(ReflectiveInvocationContext.class);
-        ExtensionContext extensionContextMock = mockTestContext();
 
         when(extensionContextMock.getRequiredTestMethod()).thenReturn(methodMock);
         when(extensionContextMock.getRequiredTestClass()).thenReturn((Class) test.getClass());
@@ -301,8 +349,9 @@ class JUnitPerfInterceptorTest {
 
         when(invocationMock.proceed()).thenThrow(new AssertionError());
 
-        interceptor.postProcessTestInstance(test, extensionContextMock);
-        interceptor.statementBuilder = statementBuilderMock;
+        interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
+
+        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
 
         assertThrows(AssertionError.class, () -> {
             interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
@@ -319,7 +368,7 @@ class JUnitPerfInterceptorTest {
         when(extensionContextMock.getRequiredTestMethod()).thenReturn(methodMock);
         when(extensionContextMock.getRequiredTestClass()).thenReturn((Class) test.getClass());
         
-        assertThrows( IllegalStateException.class, () -> interceptor.postProcessTestInstance(test, extensionContextMock));
+        assertThrows(IllegalStateException.class, () -> interceptor.postProcessTestInstance(test, getParent(extensionContextMock)));
     }
 
     @Test
@@ -329,13 +378,18 @@ class JUnitPerfInterceptorTest {
     }
 
     @Test
-    void whenInterceptorResolveParameterIsCalled_thenTestContextSupplierShouldBeReturned() {
-        assertTrue(interceptor.resolveParameter(null, null) instanceof TestContextSupplier);
+    void whenInterceptorResolveParameterIsCalled_thenTestContextSupplierShouldBeReturned() throws Exception {
+        ExtensionContext extensionContextMock = mockTestContext();
+        interceptor.postProcessTestInstance(this, getParent(extensionContextMock));
+        assertTrue(interceptor.resolveParameter(null, extensionContextMock) instanceof TestContextSupplier);
     }
     
-    private static void mockActiveSuite(ExtensionContext extensionContextMock, Class<?> suiteClass) {
-        when(extensionContextMock.getRoot()).thenReturn(extensionContextMock);
-        when(extensionContextMock.getUniqueId()).thenReturn(buildSuiteId(suiteClass));
+    private static void mockActiveSuite(ExtensionContext testMethodContext, Class<?> suiteClass) {
+        ExtensionContext suiteRoot = mock(ExtensionContext.class);
+        ExtensionContext parent = testMethodContext.getParent().get();
+        when(parent.getRoot()).thenReturn(suiteRoot);
+        when(testMethodContext.getRoot()).thenReturn(suiteRoot);
+        when(suiteRoot.getUniqueId()).thenReturn(buildSuiteId(suiteClass));
     }
 
     private static String buildSuiteId(Class<?> clazz) {
@@ -370,9 +424,24 @@ class JUnitPerfInterceptorTest {
     }
 
     private static ExtensionContext mockTestContext() {
-        ExtensionContext ctxt = mock(ExtensionContext.class);
-        when(ctxt.getUniqueId()).thenReturn("unitest" + ThreadLocalRandom.current().nextInt());
-        return ctxt;
+        ExtensionContext parent = mock(ExtensionContext.class);
+        ExtensionContext test = mock(ExtensionContext.class);
+        when(test.getUniqueId()).thenReturn("test:" + ThreadLocalRandom.current().nextInt());
+        when(parent.getUniqueId()).thenReturn("class:" + ThreadLocalRandom.current().nextInt());
+        when(test.getParent()).thenReturn(Optional.of(parent));
+        return test;
+    }
+
+    private static SharedConfig getSharedContext(ExtensionContext context) {
+        return JUnitPerfInterceptor.sharedContexts.get(context.getParent().get().getUniqueId());
+    }
+
+    private static TestDetails getTestContext(ExtensionContext context) {
+        return JUnitPerfInterceptor.testContexts.get(context.getUniqueId());
+    }
+
+    private static ExtensionContext getParent(ExtensionContext extensionContextMock) {
+        return extensionContextMock.getParent().get();
     }
 
 

--- a/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/JUnitPerfInterceptorTest.java
+++ b/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/JUnitPerfInterceptorTest.java
@@ -138,7 +138,7 @@ class JUnitPerfInterceptorTest {
 
         interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
         // Override statement builder
-        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
+        getSharedContext(extensionContextMock).setStatementBuilder(() -> statementBuilderMock);
         interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
 
         verify(invocationMock).proceed();
@@ -164,7 +164,7 @@ class JUnitPerfInterceptorTest {
 
         interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
         // Override statement builder
-        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
+        getSharedContext(extensionContextMock).setStatementBuilder(() -> statementBuilderMock);
         interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
 
         verify(invocationMock).proceed();
@@ -194,7 +194,7 @@ class JUnitPerfInterceptorTest {
 
         interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
         
-        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
+        getSharedContext(extensionContextMock).setStatementBuilder(() -> statementBuilderMock);
         
         interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
 
@@ -223,7 +223,7 @@ class JUnitPerfInterceptorTest {
 
         interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
 
-        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
+        getSharedContext(extensionContextMock).setStatementBuilder(() -> statementBuilderMock);
 
         interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
 
@@ -250,7 +250,7 @@ class JUnitPerfInterceptorTest {
 
         interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
 
-        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
+        getSharedContext(extensionContextMock).setStatementBuilder(() -> statementBuilderMock);
 
         interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
 
@@ -286,7 +286,7 @@ class JUnitPerfInterceptorTest {
 
         interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
 
-        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
+        getSharedContext(extensionContextMock).setStatementBuilder(() -> statementBuilderMock);
 
         interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
 
@@ -324,7 +324,7 @@ class JUnitPerfInterceptorTest {
 
         interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
 
-        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
+        getSharedContext(extensionContextMock).setStatementBuilder(() -> statementBuilderMock);
         
         assertDoesNotThrow(() -> {
             interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
@@ -351,7 +351,7 @@ class JUnitPerfInterceptorTest {
 
         interceptor.postProcessTestInstance(test, getParent(extensionContextMock));
 
-        getSharedContext(extensionContextMock).setStatementBuilder(statementBuilderMock);
+        getSharedContext(extensionContextMock).setStatementBuilder(() -> statementBuilderMock);
 
         assertThrows(AssertionError.class, () -> {
             interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);

--- a/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/suite/SuiteRegistryTest.java
+++ b/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/suite/SuiteRegistryTest.java
@@ -26,7 +26,7 @@ public class SuiteRegistryTest {
     @Test
     void whenNoTestSuiteClassIsConfigured_thenSuiteShouldBeIdentified() {
         ExtensionContext context = createMockExtensionContext("[engine:junit-jupiter]");
-        SuiteRegistry.register(context);
+        SuiteRegistry.scanForSuiteDetails(context);
         assertNull(SuiteRegistry.getPerfTestData(context));
         assertNull(SuiteRegistry.getPerfRequirements(context));
         assertNull(SuiteRegistry.getReportingConfig(context));
@@ -35,7 +35,7 @@ public class SuiteRegistryTest {
     @Test
     void whenInvalidTestSuiteClassIsConfigured_thenSuiteShouldNotBeIdentified() {
         ExtensionContext context = createMockExtensionContext(buildSuiteId("com.does.not.Exist"));
-        SuiteRegistry.register(context);
+        SuiteRegistry.scanForSuiteDetails(context);
         assertNull(SuiteRegistry.getPerfTestData(context));
         assertNull(SuiteRegistry.getPerfRequirements(context));
         assertNull(SuiteRegistry.getReportingConfig(context));
@@ -44,7 +44,7 @@ public class SuiteRegistryTest {
     @Test
     void whenTestSuiteClassIsConfigured_butSuiteHasNoAnnotations_thenSuiteShouldBeIdentifiedButNoPerfDataShouldBeAvailable() {
         ExtensionContext context = createMockExtensionContext(buildSuiteId(DummySuiteNoAnnotations.class));
-        SuiteRegistry.register(context);
+        SuiteRegistry.scanForSuiteDetails(context);
         assertNull(SuiteRegistry.getPerfTestData(context));
         assertNull(SuiteRegistry.getPerfRequirements(context));
         assertNull(SuiteRegistry.getReportingConfig(context));
@@ -53,7 +53,7 @@ public class SuiteRegistryTest {
     @Test
     void whenTestSuiteClassIsConfigured_andSuiteHasPerfAnnotation_thenSuitePerfDataShouldBeAvailable() {
         ExtensionContext context = createMockExtensionContext(buildSuiteId(DummySuitePerfTestAnnotation.class));
-        SuiteRegistry.register(context);
+        SuiteRegistry.scanForSuiteDetails(context);
         JUnitPerfTest testSpec = SuiteRegistry.getPerfTestData(context);
 
         assertNotNull(testSpec);
@@ -65,7 +65,7 @@ public class SuiteRegistryTest {
     @Test
     void whenTestSuiteClassIsConfigured_andSuiteHasAllPerfAnnotations_thenSuitePerfDataShouldBeAvailable() {
         ExtensionContext context = createMockExtensionContext(buildSuiteId(DummySuitePerfTestAllAnnotations.class));
-        SuiteRegistry.register(context);
+        SuiteRegistry.scanForSuiteDetails(context);
         JUnitPerfTest testSpec = SuiteRegistry.getPerfTestData(context);
         JUnitPerfTestRequirement requirements = SuiteRegistry.getPerfRequirements(context);
 
@@ -80,7 +80,7 @@ public class SuiteRegistryTest {
     @Test
     void whenTestSuiteClassIsConfigured_andSuiteHasAllPerfAnnotationsAndReportingConfig_thenSuitePerfDataShouldBeAvailable() {
         ExtensionContext context = createMockExtensionContext(buildSuiteId(DummySuiteAllConfigs.class));
-        SuiteRegistry.register(context);
+        SuiteRegistry.scanForSuiteDetails(context);
         JUnitPerfTest testSpec = SuiteRegistry.getPerfTestData(context);
         JUnitPerfTestRequirement requirements = SuiteRegistry.getPerfRequirements(context);
         JUnitPerfReportingConfig reportConfig = SuiteRegistry.getReportingConfig(context);
@@ -97,7 +97,7 @@ public class SuiteRegistryTest {
     @Test
     void whenTestSuiteClassIsConfigured_andSuiteHasBadReporterConfig_thenSuitePerfDataShouldBeAvailable_butReporterConfigWillBeMissing() {
         ExtensionContext context = createMockExtensionContext(buildSuiteId(DummySuiteBadReporterConfigs.class));
-        SuiteRegistry.register(context);
+        SuiteRegistry.scanForSuiteDetails(context);
         JUnitPerfTest testSpec = SuiteRegistry.getPerfTestData(context);
         JUnitPerfTestRequirement requirements = SuiteRegistry.getPerfRequirements(context);
         JUnitPerfReportingConfig reportConfig = SuiteRegistry.getReportingConfig(context);


### PR DESCRIPTION
Refactoring and bug fix

## Proposed Changes

  - Refactoring JUnitPerfInterceptor logic
  - Bug fix for when `maven-surefire-plugin` is configured to run tests within a class in parallel (fix for statement build concurrency issue)
  - Update to require `@JUnitPerfTestActiveConfig` annotated fields be static

