### PR TITLE
Bug fix for suite execution & additional logging

### DIFF
--- a/junitperf-core/src/main/java/com/github/noconnor/junitperf/statements/EvaluationTask.java
+++ b/junitperf-core/src/main/java/com/github/noconnor/junitperf/statements/EvaluationTask.java
@@ -3,6 +3,7 @@ package com.github.noconnor.junitperf.statements;
 import com.github.noconnor.junitperf.statistics.StatisticsCalculator;
 import com.google.common.util.concurrent.RateLimiter;
 import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.function.Supplier;
 
@@ -11,6 +12,7 @@ import static java.util.Objects.nonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
+@Slf4j
 final class EvaluationTask implements Runnable {
 
   private final TestStatement statement;
@@ -76,7 +78,7 @@ final class EvaluationTask implements Runnable {
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       } catch (Throwable throwable) {
-        // IGNORE
+        log.trace("Warmup error", throwable);
       }
     } else {
 
@@ -85,6 +87,7 @@ final class EvaluationTask implements Runnable {
       } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
       } catch (Throwable throwable) {
+        log.trace("Setup error", throwable);
         throw new IllegalStateException("Before method failed", throwable);
       }
 
@@ -101,6 +104,7 @@ final class EvaluationTask implements Runnable {
           stats.incrementErrorCount();
           stats.addLatencyMeasurement(nanoTime() - startTimeNs);
         }
+        log.trace("Execution error", throwable);
       }
 
       try {
@@ -108,6 +112,7 @@ final class EvaluationTask implements Runnable {
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       } catch (Throwable throwable) {
+        log.trace("Teardown error", throwable);
         throw new IllegalStateException("After method failed", throwable);
       }
 

--- a/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
+++ b/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
@@ -101,10 +101,13 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
             test.setMeasurementsStartTimeMs(currentTimeMillis() + perfTestAnnotation.warmUpMs());
             test.setContext(context);
 
-            SimpleTestStatement testStatement = () -> method.invoke(
-                    extensionContext.getRequiredTestInstance(),
-                    invocationContext.getArguments().toArray()
-            );
+            SimpleTestStatement testStatement = () -> {
+                method.setAccessible(true);
+                method.invoke(
+                        extensionContext.getRequiredTestInstance(),
+                        invocationContext.getArguments().toArray()
+                );
+            };
 
             PerformanceEvaluationStatement parallelExecution = test.getStatementBuilder()
                     .baseStatement(testStatement)
@@ -198,7 +201,7 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
             // Must be called for framework to proceed
             invocation.proceed();
         } catch (Throwable e) {
-            // Ignore
+            log.trace("Proceed error", e);
         }
     }
 


### PR DESCRIPTION
Fixes bug when running as a suite

## Proposed Changes

  - When running tests suites, and test methods are not accessible to the framework, test will throw an exception. Call to method.setAccessible helps resolve this issue
  - Adding trace logging to help debug issues
