### PR TITLE
Adding support to run before each & after each for each test iteration

### DIFF
--- a/junit5-examples/src/test/java/com/github/noconnor/junitperf/examples/ExampleSuccessTests.java
+++ b/junit5-examples/src/test/java/com/github/noconnor/junitperf/examples/ExampleSuccessTests.java
@@ -26,12 +26,12 @@ public class ExampleSuccessTests {
 
     @BeforeEach
     public void setup() throws InterruptedException {
-        Thread.sleep(1_000);
+        Thread.sleep(10);
     }
 
     @AfterEach
     public void teardown() throws InterruptedException {
-        Thread.sleep(1_000);
+        Thread.sleep(10);
     }
 
     @Test

--- a/junitperf-core/src/main/java/com/github/noconnor/junitperf/statements/EvaluationTask.java
+++ b/junitperf-core/src/main/java/com/github/noconnor/junitperf/statements/EvaluationTask.java
@@ -88,7 +88,9 @@ final class EvaluationTask implements Runnable {
           Thread.currentThread().interrupt();
       } catch (Throwable throwable) {
         log.trace("Setup error", throwable);
-        throw new IllegalStateException("Before method failed", throwable);
+        if (!(throwable.getCause() instanceof InterruptedException)) {
+          throw new IllegalStateException("Before method failed", throwable);
+        }
       }
 
       long startTimeNs = nanoTime();
@@ -113,7 +115,9 @@ final class EvaluationTask implements Runnable {
         Thread.currentThread().interrupt();
       } catch (Throwable throwable) {
         log.trace("Teardown error", throwable);
-        throw new IllegalStateException("After method failed", throwable);
+        if (!(throwable.getCause() instanceof InterruptedException)) {
+          throw new IllegalStateException("After method failed", throwable);
+        }
       }
 
     }

--- a/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/statements/FullStatement.java
+++ b/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/statements/FullStatement.java
@@ -1,0 +1,47 @@
+package com.github.noconnor.junitperf.statements;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+@RequiredArgsConstructor
+public class FullStatement implements TestStatement {
+
+    @Getter
+    @Setter
+    private List<Method> beforeEach = emptyList();
+    @Getter
+    @Setter
+    private List<Method> afterEach = emptyList();
+
+    private final Object testClass;
+    private final Method testMethod;
+    private final List<Object> args;
+
+    @Override
+    public void runBefores() throws Throwable {
+        for (Method m : beforeEach) {
+            m.setAccessible(true);
+            m.invoke(testClass);
+        }
+    }
+
+    @Override
+    public void evaluate() throws Throwable {
+        testMethod.setAccessible(true);
+        testMethod.invoke(testClass, args.toArray());
+    }
+
+    @Override
+    public void runAfters() throws Throwable {
+        for (Method m : afterEach) {
+            m.setAccessible(true);
+            m.invoke(testClass);
+        }
+    }
+}

--- a/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/utils/TestReflectionUtils.java
+++ b/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/utils/TestReflectionUtils.java
@@ -1,0 +1,21 @@
+package com.github.noconnor.junitperf.utils;
+
+import lombok.experimental.UtilityClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+@UtilityClass
+public class TestReflectionUtils {
+    
+    public static List<Method> findBeforeEach(Object testClass) {
+        return ReflectionUtils.findMethods(testClass.getClass(), m -> m.isAnnotationPresent(BeforeEach.class));
+    }
+
+    public static List<Method> findAfterEach(Object testClass) {
+        return ReflectionUtils.findMethods(testClass.getClass(), m -> m.isAnnotationPresent(AfterEach.class));
+    }
+}

--- a/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/statements/FullStatementTest.java
+++ b/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/statements/FullStatementTest.java
@@ -1,0 +1,108 @@
+package com.github.noconnor.junitperf.statements;
+
+import lombok.Getter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FullStatementTest {
+    
+    private FullStatement statement;
+    
+    private MockTestInstance testInstanceMock;
+    
+    
+    @BeforeEach
+    void setup() throws NoSuchMethodException {
+        testInstanceMock = new MockTestInstance();
+        Method testMethod = MockTestInstance.class.getDeclaredMethod("someMethod");
+        statement = new FullStatement(testInstanceMock, testMethod, emptyList());
+    }
+    
+    @Test
+    void whenEvaluateIsCalled_thenMethodShouldBeInvoked() throws Throwable {
+        statement.evaluate();
+        assertEquals(1, testInstanceMock.getInvocationCount().get());
+    }
+
+    @Test
+    void whenRunBeforeIsCalled_thenNoBeforeMethodsExist_thenNoExceptionsShouldBeThrown() {
+        assertDoesNotThrow(() -> statement.runBefores());
+    }
+
+    @Test
+    void whenRunAfterIsCalled_thenNoAfterMethodsExist_thenNoExceptionsShouldBeThrown() {
+        assertDoesNotThrow(() -> statement.runAfters());
+    }
+
+    @Test
+    void whenRunBeforeIsCalled_thenBeforeMethodsExist_thenMethodsShouldBeCalled() throws NoSuchMethodException {
+        Method before1Method = MockTestInstance.class.getDeclaredMethod("before1");
+        Method before2Method = MockTestInstance.class.getDeclaredMethod("before2");
+        List<Method> beforeMethods = new ArrayList<>();
+        beforeMethods.add(before1Method);
+        beforeMethods.add(before2Method);
+        
+        statement.setBeforeEach(beforeMethods);
+        assertDoesNotThrow(() -> statement.runBefores());
+        assertEquals(1, testInstanceMock.getBefore1Count().get());
+        assertEquals(1, testInstanceMock.getBefore2Count().get());
+    }
+
+    @Test
+    void whenRunAfterIsCalled_thenAfterMethodsExist_thenMethodsShouldBeCalled() throws NoSuchMethodException {
+        Method after1Method = MockTestInstance.class.getDeclaredMethod("after1");
+        Method after2Method = MockTestInstance.class.getDeclaredMethod("after2");
+        List<Method> afterMethods = new ArrayList<>();
+        afterMethods.add(after1Method);
+        afterMethods.add(after2Method);
+
+        statement.setAfterEach(afterMethods);
+        assertDoesNotThrow(() -> statement.runAfters());
+        assertEquals(1, testInstanceMock.getAfter1Count().get());
+        assertEquals(1, testInstanceMock.getAfter2Count().get());
+    }
+
+
+    public static class MockTestInstance {
+        @Getter
+        private final AtomicInteger invocationCount = new AtomicInteger();
+        @Getter
+        private final AtomicInteger before1Count = new AtomicInteger();
+        @Getter
+        private final AtomicInteger before2Count = new AtomicInteger();
+        @Getter
+        private final AtomicInteger after1Count = new AtomicInteger();
+        @Getter
+        private final AtomicInteger after2Count = new AtomicInteger();
+        
+        private void someMethod() {
+            invocationCount.incrementAndGet();
+        }
+
+        private void before1() {
+            before1Count.incrementAndGet();
+        }
+
+        private void before2() {
+            before2Count.incrementAndGet();
+        }
+
+        private void after1() {
+            after1Count.incrementAndGet();
+        }
+
+        private void after2() {
+            after2Count.incrementAndGet();
+        }
+    }
+
+}

--- a/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/utils/TestReflectionUtilsTest.java
+++ b/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/utils/TestReflectionUtilsTest.java
@@ -1,0 +1,110 @@
+package com.github.noconnor.junitperf.utils;
+
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestReflectionUtilsTest {
+
+    @Test
+    void whenClassContainsNoBeforeAndAfterMethods_thenEmptyListShouldBeReturned() {
+        NoBeforeAfters test = new NoBeforeAfters();
+        assertEquals(emptyList(), TestReflectionUtils.findBeforeEach(test));
+        assertEquals(emptyList(), TestReflectionUtils.findAfterEach(test));
+    }
+
+    @Test
+    void whenClassContainsBeforeEach_thenNonEmptyBeforeEachListShouldBeReturned() {
+        BeforeEachClass test = new BeforeEachClass();
+        assertEquals(emptyList(), TestReflectionUtils.findAfterEach(test));
+        List<Method> beforeMethods = TestReflectionUtils.findBeforeEach(test);
+        assertEquals(1, beforeMethods.size());
+        assertEquals("setupBeforeEachClass", beforeMethods.get(0).getName());
+        assertDoesNotThrow(() -> beforeMethods.get(0).invoke(test));
+    }
+
+    @Test
+    void whenClassContainsAfterEach_thenNonEmptyAfterEachListShouldBeReturned() {
+        AfterEachClass test = new AfterEachClass();
+        assertEquals(emptyList(), TestReflectionUtils.findBeforeEach(test));
+        List<Method> afterMethods = TestReflectionUtils.findAfterEach(test);
+        assertEquals(1, afterMethods.size());
+        assertEquals("tearDownAfterEachClass", afterMethods.get(0).getName());
+        assertDoesNotThrow(() -> afterMethods.get(0).invoke(test));
+    }
+
+    @Test
+    void whenClassContainsBeforeAndAfterEach_thenNonEmptyBeforeAndAfterEachListShouldBeReturned() {
+        BeforeAndAfterClass test = new BeforeAndAfterClass();
+        List<Method> beforeMethods = TestReflectionUtils.findBeforeEach(test);
+        List<Method> afterMethods = TestReflectionUtils.findAfterEach(test);
+        assertEquals(1, beforeMethods.size());
+        assertEquals(1, afterMethods.size());
+        assertEquals("setupBeforeAndAfterClass", beforeMethods.get(0).getName());
+        assertEquals("tearDownBeforeAndAfterClass", afterMethods.get(0).getName());
+        assertDoesNotThrow(() -> beforeMethods.get(0).invoke(test));
+        assertDoesNotThrow(() -> afterMethods.get(0).invoke(test));
+    }
+
+    @Test
+    void whenClassContainsMultipleBeforeAndAfterEach_thenNonEmptyBeforeAndAfterEachListShouldBeReturned() {
+        MultipleBeforeAndAfterClass test = new MultipleBeforeAndAfterClass();
+        List<Method> beforeMethods = TestReflectionUtils.findBeforeEach(test);
+        List<Method> afterMethods = TestReflectionUtils.findAfterEach(test);
+        assertEquals(2, beforeMethods.size());
+        assertEquals(2, afterMethods.size());
+    }
+
+    @Disabled
+    public static class NoBeforeAfters {
+    }
+
+    @Disabled
+    public static class BeforeEachClass {
+        @BeforeEach
+        void setupBeforeEachClass(){
+        }
+    }
+
+    @Disabled
+    public static class AfterEachClass {
+        @AfterEach
+        void tearDownAfterEachClass(){
+        }
+    }
+
+    @Disabled
+    public static class BeforeAndAfterClass {
+        @BeforeEach
+        void setupBeforeAndAfterClass(){
+        }
+        @AfterEach
+        void tearDownBeforeAndAfterClass(){
+        }
+    }
+
+    @Disabled
+    public static class MultipleBeforeAndAfterClass {
+        @BeforeEach
+        void setup1BeforeAndAfterClass(){
+        }
+        @BeforeEach
+        void setup2BeforeAndAfterClass(){
+        }
+        @AfterEach
+        void tearDown1BeforeAndAfterClass(){
+        }
+        @AfterEach
+        void tearDown2BeforeAndAfterClass(){
+        }
+    }
+}


### PR DESCRIPTION
Currently @BeforeEach & @AfterEach are only executed once at the start & end of the performance test

## Proposed Changes

  - run all @BeforeEach method for each test run iteration
  - run all @AfterEach method for each test run iteration
