### PR TITLE
Replacing proceed call with skip call

### DIFF
--- a/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
+++ b/junitperf-junit5/src/main/java/com/github/noconnor/junitperf/JUnitPerfInterceptor.java
@@ -123,7 +123,8 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
 
             parallelExecution.runParallelEvaluation();
 
-            proceedQuietly(invocation);
+            // Must be called for framework to proceed
+            invocation.skip();
 
         } else {
             invocation.proceed();
@@ -200,16 +201,7 @@ public class JUnitPerfInterceptor implements InvocationInterceptor, TestInstance
         }
         return scanForReportingConfig(testInstance, testClass.getSuperclass());
     }
-
-    private static void proceedQuietly(Invocation<Void> invocation) throws Throwable {
-        try {
-            // Must be called for framework to proceed
-            invocation.proceed();
-        } catch (Throwable e) {
-            log.trace("Proceed error", e);
-        }
-    }
-
+    
     private static TestDetails getTestDetails(ExtensionContext extensionContext) {
         String testId = extensionContext.getUniqueId();
         testContexts.computeIfAbsent(testId, newTestId -> {

--- a/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/JUnitPerfInterceptorTest.java
+++ b/junitperf-junit5/src/test/java/com/github/noconnor/junitperf/JUnitPerfInterceptorTest.java
@@ -204,9 +204,9 @@ class JUnitPerfInterceptorTest {
         // Override statement builder
         getSharedContext(extensionContextMock).setStatementBuilder(() -> statementBuilderMock);
         interceptor.interceptTestMethod(invocationMock, invocationContextMock, extensionContextMock);
-
-        verify(invocationMock).proceed();
+        
         verify(statementMock).runParallelEvaluation();
+        verify(invocationMock).skip();
 
         assertNotNull(getTestContext(extensionContextMock));
         EvaluationContext context = captureEvaluationContext();


### PR DESCRIPTION
Fixes issue where call to proceed may fail after parallel evaluation has completed

## Proposed Changes

  - Replace call to proceed with call to skip
