### PR TITLE
Fixing some tests that failed on systems using a locale with a differing decimal or grouping separator

### DIFF
--- a/junitperf-core/src/test/java/com/github/noconnor/junitperf/reporting/providers/CsvReportGeneratorTest.java
+++ b/junitperf-core/src/test/java/com/github/noconnor/junitperf/reporting/providers/CsvReportGeneratorTest.java
@@ -2,6 +2,9 @@ package com.github.noconnor.junitperf.reporting.providers;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import com.github.noconnor.junitperf.reporting.BaseReportGeneratorTest;
@@ -13,6 +16,8 @@ import static org.junit.Assert.assertThat;
 
 public class CsvReportGeneratorTest extends BaseReportGeneratorTest {
 
+  private Locale defaultLocale;
+
   private CsvReportGenerator reportGenerator;
 
   private File reportFile;
@@ -23,6 +28,16 @@ public class CsvReportGeneratorTest extends BaseReportGeneratorTest {
     reportGenerator = new CsvReportGenerator(reportFile.getPath());
     initialisePerfTestAnnotationMock();
     initialisePerfTestRequirementAnnotationMock();
+    defaultLocale = Locale.getDefault();
+    // set local to en-US as this test expects numbers to use "."
+    // as a decimal separator and "," as a grouping separator, e.g. 1,337.42
+    Locale.setDefault(Locale.US);
+  }
+
+  @After
+  public void after() {
+    // restore default locale
+    Locale.setDefault(defaultLocale);
   }
 
   @Test

--- a/junitperf-core/src/test/java/com/github/noconnor/junitperf/reporting/providers/HtmlReportGeneratorTest.java
+++ b/junitperf-core/src/test/java/com/github/noconnor/junitperf/reporting/providers/HtmlReportGeneratorTest.java
@@ -2,11 +2,13 @@ package com.github.noconnor.junitperf.reporting.providers;
 
 import com.github.noconnor.junitperf.datetime.DatetimeUtils;
 import com.github.noconnor.junitperf.reporting.BaseReportGeneratorTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Map;
 
 import static java.lang.System.getProperty;
@@ -17,6 +19,8 @@ import static org.junit.Assert.assertTrue;
 
 public class HtmlReportGeneratorTest extends BaseReportGeneratorTest {
 
+    private Locale defaultLocale;
+
     private HtmlReportGenerator reportGenerator;
 
     @Before
@@ -26,6 +30,16 @@ public class HtmlReportGeneratorTest extends BaseReportGeneratorTest {
         DatetimeUtils.setOverride("unittest o'clock");
         initialisePerfTestAnnotationMock();
         initialisePerfTestRequirementAnnotationMock();
+        defaultLocale = Locale.getDefault();
+        // set local to en-US as this test expects numbers to use "."
+        // as a decimal separator and "," as a grouping separator, e.g. 1,337.42
+        Locale.setDefault(Locale.US);
+    }
+
+    @After
+    public void after() {
+        // restore default locale
+        Locale.setDefault(defaultLocale);
     }
 
     @Test

--- a/junitperf-core/src/test/java/com/github/noconnor/junitperf/reporting/providers/utils/ViewDataTest.java
+++ b/junitperf-core/src/test/java/com/github/noconnor/junitperf/reporting/providers/utils/ViewDataTest.java
@@ -2,12 +2,17 @@ package com.github.noconnor.junitperf.reporting.providers.utils;
 
 import com.github.noconnor.junitperf.BaseTest;
 import com.github.noconnor.junitperf.data.EvaluationContext;
+import com.github.noconnor.junitperf.reporting.providers.HtmlReportGenerator;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.IntStream;
@@ -20,6 +25,24 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ViewDataTest extends BaseTest {
+
+    private Locale defaultLocale;
+
+    private HtmlReportGenerator reportGenerator;
+
+    @Before
+    public void setup() throws IOException {
+        defaultLocale = Locale.getDefault();
+        // set local to en-US as this test expects numbers to use "."
+        // as a decimal separator and "," as a grouping separator, e.g. 1,337.42
+        Locale.setDefault(Locale.US);
+    }
+
+    @After
+    public void after() {
+        // restore default locale
+        Locale.setDefault(defaultLocale);
+    }
 
     @Test
     public void whenSuccessfulEvaluationContextIsProvided_thenViewDataShouldBeMappedCorrectly() {


### PR DESCRIPTION
On my machine, some tests failed because numbers were formatted in a way not expected by the unit tests. With this PR, the tests themselves set the locale they expect. This way, these tests will run on all kinds of systems, regardless of the default locale they use.

Some background: In Germany, we format numbers with a decimal place like this 0,5 (= 0.5 US) and big numbers like this 10.000 (= 10,000 US).
