### PR TITLE
Fixing some tests that failed on systems that do not have UTF8 as the default charset

### DIFF
--- a/junitperf-core/src/main/java/com/github/noconnor/junitperf/reporting/providers/HtmlReportGenerator.java
+++ b/junitperf-core/src/main/java/com/github/noconnor/junitperf/reporting/providers/HtmlReportGenerator.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -106,7 +107,7 @@ public class HtmlReportGenerator implements ReportGenerator {
             root = root.replaceAll(asRegex(OVERVIEW_MARKER), overviews.toString());
             root = root.replaceAll(asRegex(DETAILS_MARKER), details.toString());
 
-            Files.write(outputPath, root.getBytes());
+            Files.write(outputPath, root.getBytes(StandardCharsets.UTF_8));
 
         } catch (Exception e) {
             throw new IllegalStateException(e);


### PR DESCRIPTION
On my machine, some tests failed because the test result was written to the tmp folder using the Latin-1 (ISO-8859-1) character set, but later read using UTF8.
This PR ensures that the test result is always written to the file using UTF8, regardless of the system's default character set.